### PR TITLE
Fix: Read keycloak version from gradle libs.versions.toml

### DIFF
--- a/.github/workflows/.build-publish-docker.yaml
+++ b/.github/workflows/.build-publish-docker.yaml
@@ -15,10 +15,14 @@ on:
         description: "Environment"
         required: true
         type: string
+      keycloak_version:
+        description: "Keycloak version for Docker ARG"
+        required: false
+        type: string
     outputs:
-      image-tags:
+      image_tags:
         description: "Docker image with tag"
-        value: ${{ jobs.publish.outputs.image-tags }}
+        value: ${{ jobs.publish.outputs.image_tags }}
 
 env:
   REGISTRY: ghcr.io
@@ -27,7 +31,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     outputs:
-      image-tags: ${{ steps.meta.outputs.tags }}
+      image_tags: ${{ steps.meta.outputs.tags }}
     steps:
       - uses: actions/checkout@v5
 
@@ -50,6 +54,15 @@ jobs:
           tags: |
             type=sha,prefix={{date 'YYYYMMDD'}}${{ steps.tag_suffix.outputs.tag_suffix }}-,priority=9002
 
+      - name: Set build args
+        id: build_args
+        run: |
+          if [ -n "${{ inputs.keycloak_version }}" ]; then
+            echo "args=KEYCLOAK_VERSION=${{ inputs.keycloak_version }}" >> $GITHUB_OUTPUT
+          else
+            echo "args=" >> $GITHUB_OUTPUT
+          fi
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v6.18.0
         with:
@@ -57,5 +70,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: ${{ steps.build_args.outputs.args }}
+
       - name: Set output
         run: echo "Docker image ${{ steps.meta.outputs.tags }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/.chart-publish.yaml
+++ b/.github/workflows/.chart-publish.yaml
@@ -3,11 +3,11 @@ name: Publish Chart
 on:
   workflow_call:
     inputs:
-      image-tags:
+      image_tags:
         description: "The image tag of the application"
         type: string
         required: true
-      chart-name:
+      chart_name:
         description: "The name of the chart"
         type: string
         required: true
@@ -31,7 +31,7 @@ jobs:
         run: |
           echo "chart_version=$(date +'%Y%m%d')-${{ steps.commit-hash.outputs.short }}" >> ${GITHUB_OUTPUT}
 
-          full_tag="${{ inputs.image-tags }}"
+          full_tag="${{ inputs.image_tags }}"
           version="${full_tag##*:}"
           echo "Extracted version: $version"
           echo "app_version=$version" >> $GITHUB_OUTPUT
@@ -40,14 +40,14 @@ jobs:
         uses: mikefarah/yq@v4.47.2
         with:
           cmd: |
-            yq e -i '.version = "${{ steps.versions.outputs.chart_version }}"' ./charts/${{ inputs.chart-name }}/Chart.yaml
-            yq e -i '.appVersion = "${{ steps.versions.outputs.app_version }}"' ./charts/${{ inputs.chart-name }}/Chart.yaml
+            yq e -i '.version = "${{ steps.versions.outputs.chart_version }}"' ./charts/${{ inputs.chart_name }}/Chart.yaml
+            yq e -i '.appVersion = "${{ steps.versions.outputs.app_version }}"' ./charts/${{ inputs.chart_name }}/Chart.yaml
 
       - name: Save Chart Meta
         uses: actions/upload-artifact@v4.6.2
         with:
-          name: ${{ inputs.chart-name }}-chart-metadata
-          path: ./charts/${{ inputs.chart-name }}/Chart.yaml
+          name: ${{ inputs.chart_name }}-chart-metadata
+          path: ./charts/${{ inputs.chart_name }}/Chart.yaml
 
   publish-chart:
     name: Publish Helm Chart
@@ -65,8 +65,8 @@ jobs:
       - name: Restore Chart Metadata
         uses: actions/download-artifact@v5.0.0
         with:
-          name: ${{ inputs.chart-name }}-chart-metadata
-          path: ./charts/${{ inputs.chart-name }}
+          name: ${{ inputs.chart_name }}-chart-metadata
+          path: ./charts/${{ inputs.chart_name }}
 
       - uses: azure/setup-helm@v4.3.1
         name: Setup Helm
@@ -76,8 +76,8 @@ jobs:
 
       - name: Build Charts
         run: |
-          helm package ./charts/${{ inputs.chart-name }} -d ./charts/${{ inputs.chart-name }}
+          helm package ./charts/${{ inputs.chart_name }} -d ./charts/${{ inputs.chart_name }}
 
       - name: Push Charts
         run: |
-          helm push ./charts/${{ inputs.chart-name }}/*.tgz oci://${{ vars.FLAIS_HELM_ENDPOINT }}/helm
+          helm push ./charts/${{ inputs.chart_name }}/*.tgz oci://${{ vars.FLAIS_HELM_ENDPOINT }}/helm

--- a/.github/workflows/.create-release.yaml
+++ b/.github/workflows/.create-release.yaml
@@ -3,8 +3,8 @@ name: Create release
 on:
   workflow_call:
     inputs:
-      image-tags:
-        description: 'Docker image with tag'
+      image_tags:
+        description: "Docker image with tag"
         required: true
         type: string
 
@@ -21,7 +21,7 @@ jobs:
       - name: Extract tag from image reference
         id: version
         run: |
-          full_tag="${{ inputs.image-tags }}"
+          full_tag="${{ inputs.image_tags }}"
           version="${full_tag##*:}"
           echo "Extracted version: $version"
           echo "version=$version" >> $GITHUB_OUTPUT

--- a/.github/workflows/.extract-keycloak-version.yaml
+++ b/.github/workflows/.extract-keycloak-version.yaml
@@ -1,0 +1,39 @@
+name: Extract Keycloak version
+
+on:
+  workflow_call:
+    inputs:
+      libs_versions_path:
+        description: "Path to libs.versions.toml"
+        required: true
+        type: string
+    outputs:
+      keycloak_version:
+        description: "Keycloak version from libs.versions.toml"
+        value: ${{ jobs.extract.outputs.keycloak_version }}
+
+jobs:
+  extract:
+    runs-on: ubuntu-latest
+    outputs:
+      keycloak_version: ${{ steps.parse.outputs.keycloak_version }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - id: parse
+        name: Read keycloak version from TOML
+        env:
+          LIBS_VERSIONS_PATH: ${{ inputs.libs_versions_path }}
+        run: |
+          python - <<'PY'
+          import os, tomllib
+          path = os.environ.get("LIBS_VERSIONS_PATH", "libs.versions.toml")
+          with open(path, "rb") as f:
+              data = tomllib.load(f)
+          v = data["versions"]["keycloak"]
+          with open(os.environ["GITHUB_OUTPUT"], "a") as out:
+              out.write(f"keycloak_version={v}\n")
+          PY
+
+      - name: Show extracted version
+        run: echo "Extracted KEYCLOAK_VERSION=${{ steps.parse.outputs.keycloak_version }}"

--- a/.github/workflows/build-publish-release-keycloak.yaml
+++ b/.github/workflows/build-publish-release-keycloak.yaml
@@ -17,22 +17,31 @@ permissions:
   packages: write
 
 jobs:
+  keycloak-version:
+    name: Read Keycloak version
+    uses: ./.github/workflows/.extract-keycloak-version.yaml
+    with:
+      libs_versions_path: ./keycloak/gradle/libs.versions.toml
+    secrets: inherit
+
   build-publish:
     name: Build and Publish Flais Keycloak
     uses: ./.github/workflows/.build-publish-docker.yaml
+    needs: keycloak-version
     secrets: inherit
     with:
       image_name: ${{ github.repository }}
       context: ./keycloak
       environment: ${{ inputs.environment }}
+      keycloak_version: ${{ needs.keycloak-version.outputs.keycloak_version }}
 
   publish-chart:
     name: Publish Flais Keycloak Helm Chart
     needs: build-publish
     uses: ./.github/workflows/.chart-publish.yaml
     with:
-      image-tags: ${{ needs.build-publish.outputs.image-tags }}
-      chart-name: ${{ github.event.repository.name }}
+      image_tags: ${{ needs.build-publish.outputs.image_tags }}
+      chart_name: ${{ github.event.repository.name }}
     secrets: inherit
 
   create-release:
@@ -44,4 +53,4 @@ jobs:
       - publish-chart
     secrets: inherit
     with:
-      image-tags: ${{ needs.build-publish.outputs.image-tags }}
+      image_tags: ${{ needs.build-publish.outputs.image_tags }}


### PR DESCRIPTION
This PR includes the following:
- Added module to read Keycloak version from specified libs.versions.toml
- Hooked up workflow for building and publishing docker to use read Keycloak version
- Refactored variables to use recommended snake_case instead of "-"