### PR TITLE
FLA-1657: Refactor test environment packages and centralize Keycloak test fixtures

### DIFF
--- a/keycloak/src/test/common/kotlin/no/novari/test/common/annotations/PwTest.kt
+++ b/keycloak/src/test/common/kotlin/no/novari/test/common/annotations/PwTest.kt
@@ -1,8 +1,8 @@
 package no.novari.test.common.annotations
 
-import no.novari.test.common.extensions.kc.KcEnvExtension
-import no.novari.test.common.extensions.pw.PwArtifactsOnFailureExtension
-import no.novari.test.common.extensions.pw.PwEnvExtension
+import no.novari.test.common.environment.kc.KcEnvironmentExtension
+import no.novari.test.common.environment.pw.PwArtifactsOnFailureExtension
+import no.novari.test.common.environment.pw.PwEnvironmentExtension
 import org.junit.jupiter.api.extension.ExtendWith
 
 /**
@@ -13,8 +13,8 @@ import org.junit.jupiter.api.extension.ExtendWith
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
 @ExtendWith(
-    KcEnvExtension::class,
+    KcEnvironmentExtension::class,
     PwArtifactsOnFailureExtension::class,
-    PwEnvExtension::class,
+    PwEnvironmentExtension::class,
 )
 annotation class PwTest

--- a/keycloak/src/test/common/kotlin/no/novari/test/common/environment/SharedExtensionStore.kt
+++ b/keycloak/src/test/common/kotlin/no/novari/test/common/environment/SharedExtensionStore.kt
@@ -1,4 +1,4 @@
-package no.novari.test.common.extensions
+package no.novari.test.common.environment
 
 import org.junit.jupiter.api.extension.ExtensionContext
 

--- a/keycloak/src/test/common/kotlin/no/novari/test/common/environment/kc/KcEnvironment.kt
+++ b/keycloak/src/test/common/kotlin/no/novari/test/common/environment/kc/KcEnvironment.kt
@@ -1,4 +1,4 @@
-package no.novari.test.common.utils.kc
+package no.novari.test.common.environment.kc
 
 /**
  * Testcontainers-based environment for running Keycloak and related providers in tests.

--- a/keycloak/src/test/common/kotlin/no/novari/test/common/environment/kc/KcEnvironmentExtension.kt
+++ b/keycloak/src/test/common/kotlin/no/novari/test/common/environment/kc/KcEnvironmentExtension.kt
@@ -1,12 +1,10 @@
-package no.novari.test.common.extensions.kc
+package no.novari.test.common.environment.kc
 
 import no.novari.test.common.config.KcConfig
-import no.novari.test.common.extensions.SharedExtensionStore.KC_CFG
-import no.novari.test.common.extensions.SharedExtensionStore.KC_ENV
-import no.novari.test.common.extensions.SharedExtensionStore.NS
-import no.novari.test.common.utils.kc.KcAdminClient
-import no.novari.test.common.utils.kc.KcEnvironment
-import no.novari.test.common.utils.kc.LocalKcEnvironment
+import no.novari.test.common.environment.SharedExtensionStore.KC_CFG
+import no.novari.test.common.environment.SharedExtensionStore.KC_ENV
+import no.novari.test.common.environment.SharedExtensionStore.NS
+import no.novari.test.common.utils.KcAdminClient
 import org.junit.jupiter.api.extension.AfterAllCallback
 import org.junit.jupiter.api.extension.BeforeAllCallback
 import org.junit.jupiter.api.extension.ExtensionConfigurationException
@@ -22,9 +20,9 @@ import java.nio.file.Paths
  * JUnit 5 extension that manages the lifecycle of a Keycloak environment for tests.
  *
  * Responsibilities:
- * - Starts a [KcEnvironment] (Keycloak + Support containers via Testcontainers/Compose) once.
+ * - Starts a [KcEnvironmentExtension] (Keycloak + Support containers via Testcontainers/Compose) once.
  * - Stops and cleans up the environment after all tests in the class have run.
- * - Provides parameter injection: test methods can declare [KcEnvironment], [KcConfig] parameters,
+ * - Provides parameter injection: test methods can declare [KcEnvironmentExtension], [KcConfig] parameters,
  *   and JUnit will resolve it automatically using this extension.
  *
  * How it works:
@@ -34,7 +32,7 @@ import java.nio.file.Paths
  *
  * This extension is intended for testing against a fixed environment.
  */
-class KcEnvExtension :
+class KcEnvironmentExtension :
     BeforeAllCallback,
     AfterAllCallback,
     ParameterResolver {

--- a/keycloak/src/test/common/kotlin/no/novari/test/common/environment/kc/LocalKcEnvironment.kt
+++ b/keycloak/src/test/common/kotlin/no/novari/test/common/environment/kc/LocalKcEnvironment.kt
@@ -1,4 +1,4 @@
-package no.novari.test.common.utils.kc
+package no.novari.test.common.environment.kc
 
 import org.testcontainers.containers.ComposeContainer
 import org.testcontainers.containers.wait.strategy.Wait

--- a/keycloak/src/test/common/kotlin/no/novari/test/common/environment/pw/PwArtifactsOnFailureExtension.kt
+++ b/keycloak/src/test/common/kotlin/no/novari/test/common/environment/pw/PwArtifactsOnFailureExtension.kt
@@ -1,8 +1,7 @@
-package no.novari.test.common.extensions.pw
+package no.novari.test.common.environment.pw
 
 import com.microsoft.playwright.Page
 import com.microsoft.playwright.Tracing
-import no.novari.test.common.utils.pw.PwEnvironment
 import org.junit.jupiter.api.extension.AfterTestExecutionCallback
 import org.junit.jupiter.api.extension.BeforeTestExecutionCallback
 import org.junit.jupiter.api.extension.ExtensionContext

--- a/keycloak/src/test/common/kotlin/no/novari/test/common/environment/pw/PwEnvironment.kt
+++ b/keycloak/src/test/common/kotlin/no/novari/test/common/environment/pw/PwEnvironment.kt
@@ -1,4 +1,4 @@
-package no.novari.test.common.utils.pw
+package no.novari.test.common.environment.pw
 
 import com.microsoft.playwright.Browser
 import com.microsoft.playwright.BrowserContext
@@ -7,6 +7,7 @@ import com.microsoft.playwright.Page
 import com.microsoft.playwright.Playwright
 import com.microsoft.playwright.Tracing
 import org.junit.jupiter.api.extension.ExtensionConfigurationException
+import java.lang.management.ManagementFactory
 
 /**
  * Manages a Playwright lifecycle for tests, providing browser sessions with tracing enabled.
@@ -60,7 +61,7 @@ class PwEnvironment : AutoCloseable {
             }
 
         val isDebug =
-            java.lang.management.ManagementFactory
+            ManagementFactory
                 .getRuntimeMXBean()
                 .inputArguments
                 .any { it.contains("-agentlib:jdwp") }

--- a/keycloak/src/test/common/kotlin/no/novari/test/common/environment/pw/PwEnvironmentExtension.kt
+++ b/keycloak/src/test/common/kotlin/no/novari/test/common/environment/pw/PwEnvironmentExtension.kt
@@ -1,13 +1,12 @@
-package no.novari.test.common.extensions.pw
+package no.novari.test.common.environment.pw
 
 import com.microsoft.playwright.Page
-import no.novari.test.common.extensions.SharedExtensionStore
-import no.novari.test.common.extensions.SharedExtensionStore.PW_BROWSER_NAME
-import no.novari.test.common.extensions.SharedExtensionStore.PW_ENV
-import no.novari.test.common.extensions.SharedExtensionStore.PW_PAGE
-import no.novari.test.common.extensions.SharedExtensionStore.PW_SESSION
-import no.novari.test.common.utils.kc.KcEnvironment
-import no.novari.test.common.utils.pw.PwEnvironment
+import no.novari.test.common.environment.SharedExtensionStore
+import no.novari.test.common.environment.SharedExtensionStore.PW_BROWSER_NAME
+import no.novari.test.common.environment.SharedExtensionStore.PW_ENV
+import no.novari.test.common.environment.SharedExtensionStore.PW_PAGE
+import no.novari.test.common.environment.SharedExtensionStore.PW_SESSION
+import no.novari.test.common.environment.kc.KcEnvironment
 import org.junit.jupiter.api.extension.AfterAllCallback
 import org.junit.jupiter.api.extension.AfterEachCallback
 import org.junit.jupiter.api.extension.BeforeAllCallback
@@ -22,7 +21,7 @@ import org.junit.jupiter.api.extension.TestTemplateInvocationContext
 import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider
 import java.util.stream.Stream
 
-class PwEnvExtension :
+class PwEnvironmentExtension :
     BeforeAllCallback,
     AfterAllCallback,
     TestTemplateInvocationContextProvider,

--- a/keycloak/src/test/common/kotlin/no/novari/test/common/fixture/TestStrings.kt
+++ b/keycloak/src/test/common/kotlin/no/novari/test/common/fixture/TestStrings.kt
@@ -1,0 +1,66 @@
+package no.novari.test.common.fixture
+
+object TestStrings {
+    object Clients {
+        const val FLAIS_KEYCLOAK_DEMO = "flais-keycloak-demo"
+        const val FLAIS_KEYCLOAK_DEMO_ENTRA = "flais-keycloak-demo-entra"
+        const val FLAIS_KEYCLOAK_DEMO_IDPORTEN = "flais-keycloak-demo-idporten"
+        const val FLAIS_KEYCLOAK_DEMO_INVALID = "flais-keycloak-demo-invalid"
+        const val FLAIS_KEYCLOAK_DEMO_NOT_TELEMARK = "flais-keycloak-demo-not-telemark"
+        const val FLAIS_KEYCLOAK_DEMO_TELEMARK = "flais-keycloak-demo-telemark"
+        const val QLIK = "qlik"
+    }
+
+    object Orgs {
+        const val IDPORTEN = "idporten"
+        const val INNLANDET = "innlandet"
+        const val INVALID = "invalid-org"
+        const val NON_EXISTING = "nonExistingOrg"
+        const val ROGALAND = "rogaland"
+        const val ROGALAND_DISPLAY_NAME = "Rogaland"
+        const val TELEMARK = "telemark"
+        const val TELEMARK_DISPLAY_NAME = "Telemark"
+    }
+
+    object Idps {
+        const val ENTRA_ROGALAND = "entra-rogaland"
+        const val ENTRA_TELEMARK = "entra-telemark"
+        const val ENTRA_TELEMARK_ALT = "entra-telemark-alt"
+        const val IDPORTEN = "idporten"
+        const val NON_EXISTING = "non-existing-idp"
+
+        fun entra(orgAlias: String) = "entra-$orgAlias"
+    }
+
+    object Users {
+        const val ALICE_FIRST_NAME = "Alice"
+        const val ALICE_ROGALAND = "alice.basic@rogaland.no"
+        const val ALICE_TELEMARK = "alice.basic@telemark.no"
+        const val JON_FIRST_NAME = "Jon"
+        const val JON_ROGALAND = "jon.basic@rogaland.no"
+        const val JON_TELEMARK = "jon.basic@telemark.no"
+        const val SCIMVERIFY_FIRST_NAME = "Scimverify"
+        const val BASIC_LAST_NAME = "Basic"
+        const val PASSWORD = "password"
+
+        fun alice(orgAlias: String) = "alice.basic@$orgAlias.no"
+        fun qlikBasic(orgAlias: String) = "qlik.basic@$orgAlias.no"
+        fun scimVerify(orgAlias: String) = "scimverify.user@$orgAlias.no"
+    }
+
+    object Realms {
+        const val EXTERNAL = "external"
+    }
+
+    object Scopes {
+        const val PROFILE_EMAIL = "profile email"
+        const val PROFILE_EMAIL_ORGANIZATION = "profile email organization"
+        const val ORGANIZATION = "organization"
+    }
+
+    object Pages {
+        const val ERROR = "error"
+        const val FLAIS_ORG_IDP_SELECTOR = "flais-org-idp-selector"
+        const val FLAIS_ORG_SELECTOR = "flais-org-selector"
+    }
+}

--- a/keycloak/src/test/common/kotlin/no/novari/test/common/fixture/TestStrings.kt
+++ b/keycloak/src/test/common/kotlin/no/novari/test/common/fixture/TestStrings.kt
@@ -44,7 +44,9 @@ object TestStrings {
         const val PASSWORD = "password"
 
         fun alice(orgAlias: String) = "alice.basic@$orgAlias.no"
+
         fun qlikBasic(orgAlias: String) = "qlik.basic@$orgAlias.no"
+
         fun scimVerify(orgAlias: String) = "scimverify.user@$orgAlias.no"
     }
 

--- a/keycloak/src/test/common/kotlin/no/novari/test/common/fixture/TestStrings.kt
+++ b/keycloak/src/test/common/kotlin/no/novari/test/common/fixture/TestStrings.kt
@@ -1,6 +1,10 @@
 package no.novari.test.common.fixture
 
 object TestStrings {
+    object Uris {
+        fun redirectCallback(base: String) = "$base/callback"
+    }
+
     object Clients {
         const val FLAIS_KEYCLOAK_DEMO = "flais-keycloak-demo"
         const val FLAIS_KEYCLOAK_DEMO_ENTRA = "flais-keycloak-demo-entra"

--- a/keycloak/src/test/common/kotlin/no/novari/test/common/utils/KcAdminClient.kt
+++ b/keycloak/src/test/common/kotlin/no/novari/test/common/utils/KcAdminClient.kt
@@ -1,5 +1,6 @@
-package no.novari.test.common.utils.kc
+package no.novari.test.common.utils
 
+import no.novari.test.common.environment.kc.KcEnvironment
 import org.keycloak.admin.client.CreatedResponseUtil
 import org.keycloak.admin.client.Keycloak
 import org.keycloak.admin.client.KeycloakBuilder

--- a/keycloak/src/test/common/kotlin/no/novari/test/common/utils/KcUrl.kt
+++ b/keycloak/src/test/common/kotlin/no/novari/test/common/utils/KcUrl.kt
@@ -1,6 +1,7 @@
 package no.novari.test.common.utils
 
 import no.novari.test.common.environment.kc.KcEnvironment
+import no.novari.test.common.fixture.TestStrings.Uris
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import java.security.MessageDigest
@@ -37,7 +38,7 @@ object KcUrl {
     fun authUrl(
         env: KcEnvironment,
         clientId: String,
-        redirectUri: String = "${env.flaisKeycloakDemoUrl()}/callback",
+        redirectUri: String = Uris.redirectCallback(env.flaisKeycloakDemoUrl()),
         scope: String? = null,
         usePkce: Boolean = true,
         pkcePlain: Boolean = false,

--- a/keycloak/src/test/common/kotlin/no/novari/test/common/utils/KcUrl.kt
+++ b/keycloak/src/test/common/kotlin/no/novari/test/common/utils/KcUrl.kt
@@ -1,5 +1,6 @@
-package no.novari.test.common.utils.kc
+package no.novari.test.common.utils
 
+import no.novari.test.common.environment.kc.KcEnvironment
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import java.security.MessageDigest

--- a/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/authenticators/ClientOrgAccessAuthenticatorTest.kt
+++ b/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/authenticators/ClientOrgAccessAuthenticatorTest.kt
@@ -1,7 +1,12 @@
 package no.novari.test.integration.application.authenticators
 
-import no.novari.test.common.extensions.kc.KcEnvExtension
-import no.novari.test.common.utils.kc.KcEnvironment
+import no.novari.test.common.environment.kc.KcEnvironment
+import no.novari.test.common.environment.kc.KcEnvironmentExtension
+import no.novari.test.common.fixture.TestStrings.Clients
+import no.novari.test.common.fixture.TestStrings.Idps
+import no.novari.test.common.fixture.TestStrings.Orgs
+import no.novari.test.common.fixture.TestStrings.Pages
+import no.novari.test.common.fixture.TestStrings.Users
 import no.novari.test.integration.utils.KcContextParser
 import no.novari.test.integration.utils.KcFlow.continueFromAuthentikIdp
 import no.novari.test.integration.utils.KcFlow.continueFromIdpSelector
@@ -13,22 +18,19 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
-@ExtendWith(KcEnvExtension::class)
+@ExtendWith(KcEnvironmentExtension::class)
 class ClientOrgAccessAuthenticatorTest {
-    private val rogalandEmail = "alice.basic@rogaland.no"
-    private val rogalandPassword = "password"
-
     @Test
     fun `tampering broker login url to different idp is denied by post login flow with client-org-access-authenticator`(
         env: KcEnvironment,
     ) {
         loginWithUser(
             env = env,
-            clientId = "flais-keycloak-demo",
-            orgAlias = "rogaland",
-            idpAlias = "entra-rogaland",
-            username = rogalandEmail,
-            password = rogalandPassword,
+            clientId = Clients.FLAIS_KEYCLOAK_DEMO,
+            orgAlias = Orgs.ROGALAND,
+            idpAlias = Orgs.ROGALAND,
+            username = Users.ALICE_ROGALAND,
+            password = Users.PASSWORD,
             hasIdpSelector = false,
         ).use { resp ->
             assertEquals(200, resp.code)
@@ -36,13 +38,13 @@ class ClientOrgAccessAuthenticatorTest {
 
         val client = KcHttpClient.create(followRedirects = false)
 
-        openAuthUrl(env = env, clientId = "flais-keycloak-demo-telemark", httpClient = client).use { resp ->
+        openAuthUrl(env = env, clientId = Clients.FLAIS_KEYCLOAK_DEMO_TELEMARK, httpClient = client).use { resp ->
             assertEquals(200, resp.code)
 
             val html = resp.body.string()
             val kc = KcContextParser.parseKcContext(html)
 
-            continueFromIdpSelector(kc.url.loginAction!!, "entra-telemark", client).use { resp ->
+            continueFromIdpSelector(kc.url.loginAction!!, Idps.ENTRA_TELEMARK, client).use { resp ->
                 assertEquals(303, resp.code)
 
                 val redirectUrl =
@@ -52,7 +54,7 @@ class ClientOrgAccessAuthenticatorTest {
                 val req =
                     Request
                         .Builder()
-                        .url(redirectUrl.replace("entra-telemark", "entra-rogaland"))
+                        .url(redirectUrl.replace(Idps.ENTRA_TELEMARK, Idps.ENTRA_ROGALAND))
                         .build()
 
                 val client =
@@ -65,13 +67,13 @@ class ClientOrgAccessAuthenticatorTest {
                 client.newCall(req).execute().use { resp ->
                     assertEquals(200, resp.code)
 
-                    continueFromAuthentikIdp(resp.request.url, rogalandEmail, rogalandPassword, client).use { resp ->
+                    continueFromAuthentikIdp(resp.request.url, Users.ALICE_ROGALAND, Users.PASSWORD, client).use { resp ->
                         assertEquals(200, resp.code)
 
                         val html = resp.body.string()
                         val kc = KcContextParser.parseKcContext(html)
 
-                        assertEquals("error", kc.pageId)
+                        assertEquals(Pages.ERROR, kc.pageId)
                         assertEquals("error", kc.message!!.type)
                         assertEquals("Your organization does not have access to this application", kc.message.summary)
                     }

--- a/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/authenticators/ClientOrgAccessAuthenticatorTest.kt
+++ b/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/authenticators/ClientOrgAccessAuthenticatorTest.kt
@@ -28,7 +28,7 @@ class ClientOrgAccessAuthenticatorTest {
             env = env,
             clientId = Clients.FLAIS_KEYCLOAK_DEMO,
             orgAlias = Orgs.ROGALAND,
-            idpAlias = Orgs.ROGALAND,
+            idpAlias = Idps.ENTRA_ROGALAND,
             username = Users.ALICE_ROGALAND,
             password = Users.PASSWORD,
             hasIdpSelector = false,

--- a/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/authenticators/OrgCookieAuthenticatorTest.kt
+++ b/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/authenticators/OrgCookieAuthenticatorTest.kt
@@ -4,9 +4,9 @@ import no.novari.test.common.environment.kc.KcEnvironment
 import no.novari.test.common.environment.kc.KcEnvironmentExtension
 import no.novari.test.common.fixture.TestStrings.Clients
 import no.novari.test.common.fixture.TestStrings.Idps
-import no.novari.test.common.fixture.TestStrings.Scopes
 import no.novari.test.common.fixture.TestStrings.Orgs
 import no.novari.test.common.fixture.TestStrings.Pages
+import no.novari.test.common.fixture.TestStrings.Scopes
 import no.novari.test.common.fixture.TestStrings.Users
 import no.novari.test.integration.utils.KcContextParser
 import no.novari.test.integration.utils.KcFlow.loginWithUser

--- a/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/authenticators/OrgCookieAuthenticatorTest.kt
+++ b/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/authenticators/OrgCookieAuthenticatorTest.kt
@@ -1,7 +1,13 @@
 package no.novari.test.integration.application.authenticators
 
-import no.novari.test.common.extensions.kc.KcEnvExtension
-import no.novari.test.common.utils.kc.KcEnvironment
+import no.novari.test.common.environment.kc.KcEnvironment
+import no.novari.test.common.environment.kc.KcEnvironmentExtension
+import no.novari.test.common.fixture.TestStrings.Clients
+import no.novari.test.common.fixture.TestStrings.Idps
+import no.novari.test.common.fixture.TestStrings.Scopes
+import no.novari.test.common.fixture.TestStrings.Orgs
+import no.novari.test.common.fixture.TestStrings.Pages
+import no.novari.test.common.fixture.TestStrings.Users
 import no.novari.test.integration.utils.KcContextParser
 import no.novari.test.integration.utils.KcFlow.loginWithUser
 import no.novari.test.integration.utils.KcFlow.openAuthUrl
@@ -11,13 +17,13 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertNotNull
 import org.junit.jupiter.api.extension.ExtendWith
 
-@ExtendWith(KcEnvExtension::class)
+@ExtendWith(KcEnvironmentExtension::class)
 class OrgCookieAuthenticatorTest {
-    private val email = "alice.basic@telemark.no"
-    private val password = "password"
-    private val clientId = "flais-keycloak-demo"
-    private val orgAlias = "telemark"
-    private val idpAlias = "entra-telemark"
+    private val username = Users.ALICE_TELEMARK
+    private val password = Users.PASSWORD
+    private val clientId = Clients.FLAIS_KEYCLOAK_DEMO
+    private val orgAlias = Orgs.TELEMARK
+    private val idpAlias = Idps.ENTRA_TELEMARK
 
     @Test
     fun `without identity cookie falls through to organization flow`(env: KcEnvironment) {
@@ -27,7 +33,7 @@ class OrgCookieAuthenticatorTest {
             val html = resp.body.string()
             val kc = KcContextParser.parseKcContext(html)
 
-            assertEquals("flais-org-selector", kc.pageId)
+            assertEquals(Pages.FLAIS_ORG_SELECTOR, kc.pageId)
         }
     }
 
@@ -35,10 +41,10 @@ class OrgCookieAuthenticatorTest {
     fun `identity cookie with organization scope and allowed telemark org restores organization and returns code`(env: KcEnvironment) {
         val client = KcHttpClient.create(followRedirects = true)
 
-        loginWithUser(env, clientId, orgAlias, idpAlias, email, password, client, scope = "organization").use { resp ->
+        loginWithUser(env, clientId, orgAlias, idpAlias, username, password, client, scope = Scopes.ORGANIZATION).use { resp ->
             assertEquals(200, resp.code)
 
-            openAuthUrl(env = env, clientId = clientId, httpClient = client, scope = "organization").use { resp ->
+            openAuthUrl(env = env, clientId = clientId, httpClient = client, scope = Scopes.ORGANIZATION).use { resp ->
                 assertEquals(200, resp.code)
 
                 assertNotNull(resp.request.url.queryParameter("code"))
@@ -50,21 +56,21 @@ class OrgCookieAuthenticatorTest {
     fun `identity cookie with organization scope and client org access denied falls through to organization flow`(env: KcEnvironment) {
         val client = KcHttpClient.create(followRedirects = true)
 
-        loginWithUser(env, clientId, orgAlias, idpAlias, email, password, client, scope = "organization").use { resp ->
+        loginWithUser(env, clientId, orgAlias, idpAlias, username, password, client, scope = Scopes.ORGANIZATION).use { resp ->
             assertEquals(200, resp.code)
 
             openAuthUrl(
                 env = env,
-                clientId = "flais-keycloak-demo-not-telemark",
+                clientId = Clients.FLAIS_KEYCLOAK_DEMO_NOT_TELEMARK,
                 httpClient = client,
-                scope = "organization",
+                scope = Scopes.ORGANIZATION,
             ).use { resp ->
                 assertEquals(200, resp.code)
 
                 val html = resp.body.string()
                 val kc = KcContextParser.parseKcContext(html)
 
-                assertEquals("flais-org-selector", kc.pageId)
+                assertEquals(Pages.FLAIS_ORG_SELECTOR, kc.pageId)
             }
         }
     }

--- a/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/authenticators/OrgIdpSelectionUiAuthenticatorTest.kt
+++ b/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/authenticators/OrgIdpSelectionUiAuthenticatorTest.kt
@@ -2,10 +2,10 @@ package no.novari.test.integration.application.authenticators
 
 import no.novari.test.common.environment.kc.KcEnvironment
 import no.novari.test.common.environment.kc.KcEnvironmentExtension
-import no.novari.test.common.fixture.TestStrings.Pages
-import no.novari.test.common.fixture.TestStrings.Orgs
 import no.novari.test.common.fixture.TestStrings.Clients
 import no.novari.test.common.fixture.TestStrings.Idps
+import no.novari.test.common.fixture.TestStrings.Orgs
+import no.novari.test.common.fixture.TestStrings.Pages
 import no.novari.test.integration.utils.KcContextParser
 import no.novari.test.integration.utils.KcFlow.continueFromIdpSelector
 import no.novari.test.integration.utils.KcFlow.selectOrgAndContinueToIdpSelector

--- a/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/authenticators/OrgIdpSelectionUiAuthenticatorTest.kt
+++ b/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/authenticators/OrgIdpSelectionUiAuthenticatorTest.kt
@@ -1,7 +1,11 @@
 package no.novari.test.integration.application.authenticators
 
-import no.novari.test.common.extensions.kc.KcEnvExtension
-import no.novari.test.common.utils.kc.KcEnvironment
+import no.novari.test.common.environment.kc.KcEnvironment
+import no.novari.test.common.environment.kc.KcEnvironmentExtension
+import no.novari.test.common.fixture.TestStrings.Pages
+import no.novari.test.common.fixture.TestStrings.Orgs
+import no.novari.test.common.fixture.TestStrings.Clients
+import no.novari.test.common.fixture.TestStrings.Idps
 import no.novari.test.integration.utils.KcContextParser
 import no.novari.test.integration.utils.KcFlow.continueFromIdpSelector
 import no.novari.test.integration.utils.KcFlow.selectOrgAndContinueToIdpSelector
@@ -12,22 +16,22 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertNotNull
 import org.junit.jupiter.api.extension.ExtendWith
 
-@ExtendWith(KcEnvExtension::class)
+@ExtendWith(KcEnvironmentExtension::class)
 class OrgIdpSelectionUiAuthenticatorTest {
     @Test
     fun `org (telemark) login with unlinked idp returns error`(env: KcEnvironment) {
         val client = KcHttpClient.create()
-        selectOrgAndContinueToIdpSelector(env, "flais-keycloak-demo", "telemark", client).use { resp ->
+        selectOrgAndContinueToIdpSelector(env, Clients.FLAIS_KEYCLOAK_DEMO, Orgs.TELEMARK, client).use { resp ->
             assertEquals(200, resp.code)
 
             val html = resp.body.string()
             val kc = KcContextParser.parseKcContext(html)
 
-            continueFromIdpSelector(kc.url.loginAction!!, "idporten", client).use { idpResponse ->
+            continueFromIdpSelector(kc.url.loginAction!!, Orgs.IDPORTEN, client).use { idpResponse ->
                 val responseHtml = idpResponse.body.string()
                 val responseKc = KcContextParser.parseKcContext(responseHtml)
 
-                assertEquals("error", responseKc.pageId)
+                assertEquals(Pages.ERROR, responseKc.pageId)
                 assertEquals("error", responseKc.message!!.type)
                 assertEquals(
                     "The selected identity provider is not registered to the selected organization",
@@ -40,17 +44,17 @@ class OrgIdpSelectionUiAuthenticatorTest {
     @Test
     fun `org (telemark) login with non existing idp returns error`(env: KcEnvironment) {
         val client = KcHttpClient.create()
-        selectOrgAndContinueToIdpSelector(env, "flais-keycloak-demo", "telemark", client).use { resp ->
+        selectOrgAndContinueToIdpSelector(env, Clients.FLAIS_KEYCLOAK_DEMO, Orgs.TELEMARK, client).use { resp ->
             assertEquals(200, resp.code)
 
             val html = resp.body.string()
             val kc = KcContextParser.parseKcContext(html)
 
-            continueFromIdpSelector(kc.url.loginAction!!, "non-existing-idp", client).use { idpResponse ->
+            continueFromIdpSelector(kc.url.loginAction!!, Idps.NON_EXISTING, client).use { idpResponse ->
                 val responseHtml = idpResponse.body.string()
                 val responseKc = KcContextParser.parseKcContext(responseHtml)
 
-                assertEquals("error", responseKc.pageId)
+                assertEquals(Pages.ERROR, responseKc.pageId)
                 assertEquals("error", responseKc.message!!.type)
                 assertEquals(
                     "Could not find the selected identity provider",
@@ -62,13 +66,13 @@ class OrgIdpSelectionUiAuthenticatorTest {
 
     @Test
     fun `org (innlandet) with no IDPs returns error`(env: KcEnvironment) {
-        selectOrgAndContinueToIdpSelector(env, "flais-keycloak-demo", "innlandet").use { resp ->
+        selectOrgAndContinueToIdpSelector(env, Clients.FLAIS_KEYCLOAK_DEMO, Orgs.INNLANDET).use { resp ->
             assertEquals(200, resp.code)
 
             val html = resp.body.string()
             val kc = KcContextParser.parseKcContext(html)
 
-            assertEquals("error", kc.pageId)
+            assertEquals(Pages.ERROR, kc.pageId)
             assertEquals("error", kc.message!!.type)
             assertEquals(
                 "Selected organization does not have permission to login to this application",
@@ -79,7 +83,7 @@ class OrgIdpSelectionUiAuthenticatorTest {
 
     @Test
     fun `org (idporten) with one IDP redirects to provider`(env: KcEnvironment) {
-        selectOrgAndContinueToIdpSelector(env, "flais-keycloak-demo", "idporten").use { resp ->
+        selectOrgAndContinueToIdpSelector(env, Clients.FLAIS_KEYCLOAK_DEMO, Orgs.IDPORTEN).use { resp ->
             assertEquals(303, resp.code)
 
             val loc1 = resp.header("Location").orEmpty()
@@ -92,19 +96,19 @@ class OrgIdpSelectionUiAuthenticatorTest {
     @Test
     fun `org (telemark) login with idp from org (rogaland) returns error`(env: KcEnvironment) {
         val client = KcHttpClient.create()
-        selectOrgAndContinueToIdpSelector(env, "flais-keycloak-demo", "telemark", client).use { resp ->
+        selectOrgAndContinueToIdpSelector(env, Clients.FLAIS_KEYCLOAK_DEMO, Orgs.TELEMARK, client).use { resp ->
             assertEquals(200, resp.code)
 
             val html = resp.body.string()
             val kc = KcContextParser.parseKcContext(html)
 
-            continueFromIdpSelector(kc.url.loginAction!!, "entra-rogaland", client).use { idpResponse ->
+            continueFromIdpSelector(kc.url.loginAction!!, Idps.ENTRA_ROGALAND, client).use { idpResponse ->
                 assertEquals(200, idpResponse.code)
 
                 val responseHtml = idpResponse.body.string()
                 val responseKc = KcContextParser.parseKcContext(responseHtml)
 
-                assertEquals("error", responseKc.pageId)
+                assertEquals(Pages.ERROR, responseKc.pageId)
                 assertEquals("error", responseKc.message!!.type)
                 assertEquals(
                     "The selected identity provider is not registered to the selected organization",
@@ -116,37 +120,37 @@ class OrgIdpSelectionUiAuthenticatorTest {
 
     @Test
     fun `org (telemark) with multiple IDPs returns IDPs`(env: KcEnvironment) {
-        selectOrgAndContinueToIdpSelector(env, "flais-keycloak-demo", "telemark").use { resp ->
+        selectOrgAndContinueToIdpSelector(env, Clients.FLAIS_KEYCLOAK_DEMO, Orgs.TELEMARK).use { resp ->
             assertEquals(200, resp.code)
 
             val html = resp.body.string()
             val kc = KcContextParser.parseKcContext(html)
 
-            assertEquals("flais-org-idp-selector", kc.pageId)
+            assertEquals(Pages.FLAIS_ORG_IDP_SELECTOR, kc.pageId)
             assertNotNull(kc.providers)
             assertTrue(kc.providers.size > 1)
             assertTrue(
                 kc.providers
                     .stream()
-                    .anyMatch { p: KcContextParser.Provider? -> "entra-telemark" == p!!.alias },
+                    .anyMatch { p: KcContextParser.Provider? -> Idps.ENTRA_TELEMARK == p!!.alias },
             )
             assertTrue(
                 kc.providers
                     .stream()
-                    .anyMatch { p: KcContextParser.Provider? -> "entra-telemark" == p!!.alias },
+                    .anyMatch { p: KcContextParser.Provider? -> Idps.ENTRA_TELEMARK_ALT == p!!.alias },
             )
         }
     }
 
     @Test
     fun `org (telemark) returns page flais-org-idp-selector`(env: KcEnvironment) {
-        selectOrgAndContinueToIdpSelector(env, "flais-keycloak-demo", "telemark").use { resp ->
+        selectOrgAndContinueToIdpSelector(env, Clients.FLAIS_KEYCLOAK_DEMO, Orgs.TELEMARK).use { resp ->
             assertEquals(200, resp.code)
 
             val html = resp.body.string()
             val kc = KcContextParser.parseKcContext(html)
 
-            assertEquals("flais-org-idp-selector", kc.pageId)
+            assertEquals(Pages.FLAIS_ORG_IDP_SELECTOR, kc.pageId)
         }
     }
 }

--- a/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/authenticators/OrgSelectionUiAuthenticatorTest.kt
+++ b/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/authenticators/OrgSelectionUiAuthenticatorTest.kt
@@ -1,7 +1,10 @@
 package no.novari.test.integration.application.authenticators
 
-import no.novari.test.common.extensions.kc.KcEnvExtension
-import no.novari.test.common.utils.kc.KcEnvironment
+import no.novari.test.common.environment.kc.KcEnvironment
+import no.novari.test.common.environment.kc.KcEnvironmentExtension
+import no.novari.test.common.fixture.TestStrings.Clients
+import no.novari.test.common.fixture.TestStrings.Orgs
+import no.novari.test.common.fixture.TestStrings.Pages
 import no.novari.test.integration.utils.KcContextParser
 import no.novari.test.integration.utils.KcFlow.continueFromOrgSelector
 import no.novari.test.integration.utils.KcFlow.openAuthUrl
@@ -11,36 +14,36 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
-@ExtendWith(KcEnvExtension::class)
+@ExtendWith(KcEnvironmentExtension::class)
 class OrgSelectionUiAuthenticatorTest {
     @Test
-    fun `client (flais-keycloak-demo) returns page flais-org-selector`(env: KcEnvironment) {
-        openAuthUrl(env = env, clientId = "flais-keycloak-demo").use { resp ->
+    fun `client returns page flais-org-selector`(env: KcEnvironment) {
+        openAuthUrl(env = env, clientId = Clients.FLAIS_KEYCLOAK_DEMO).use { resp ->
             assertEquals(200, resp.code)
 
             val html = resp.body.string()
             val kc = KcContextParser.parseKcContext(html)
 
-            assertEquals("flais-org-selector", kc.pageId)
+            assertEquals(Pages.FLAIS_ORG_SELECTOR, kc.pageId)
         }
     }
 
     @Test
     fun `selecting non existing organization returns error`(env: KcEnvironment) {
         val client = KcHttpClient.create()
-        openAuthUrl(env = env, clientId = "flais-keycloak-demo", httpClient = client).use { resp ->
+        openAuthUrl(env = env, clientId = Clients.FLAIS_KEYCLOAK_DEMO, httpClient = client).use { resp ->
             assertEquals(200, resp.code)
 
             val html = resp.body.string()
             val kc = KcContextParser.parseKcContext(html)
 
-            continueFromOrgSelector(kc.url.loginAction!!, "nonExistingOrg", client).use { resp ->
+            continueFromOrgSelector(kc.url.loginAction!!, Orgs.NON_EXISTING, client).use { resp ->
                 assertEquals(200, resp.code)
 
                 val html = resp.body.string()
                 val kc = KcContextParser.parseKcContext(html)
 
-                assertEquals("error", kc.pageId)
+                assertEquals(Pages.ERROR, kc.pageId)
                 assertEquals("error", kc.message!!.type)
                 assertEquals(
                     "Selected organization does not have permission to login to this application",
@@ -53,44 +56,44 @@ class OrgSelectionUiAuthenticatorTest {
     @Test
     fun `valid org (telemark) advances to next step`(env: KcEnvironment) {
         val client = KcHttpClient.create()
-        openAuthUrl(env = env, clientId = "flais-keycloak-demo", httpClient = client).use { resp ->
+        openAuthUrl(env = env, clientId = Clients.FLAIS_KEYCLOAK_DEMO, httpClient = client).use { resp ->
             assertEquals(200, resp.code)
 
             val html = resp.body.string()
             val kc = KcContextParser.parseKcContext(html)
 
-            continueFromOrgSelector(kc.url.loginAction!!, "telemark", client).use { resp ->
+            continueFromOrgSelector(kc.url.loginAction!!, Orgs.TELEMARK, client).use { resp ->
                 assertEquals(200, resp.code)
 
                 val html = resp.body.string()
                 val kc = KcContextParser.parseKcContext(html)
 
-                assertEquals("flais-org-idp-selector", kc.pageId)
+                assertEquals(Pages.FLAIS_ORG_IDP_SELECTOR, kc.pageId)
             }
         }
     }
 
     @Test
-    fun `client (flais-keycloak-demo-telemark) with 1 org directly to flais-org-idp-selector`(env: KcEnvironment) {
-        openAuthUrl(env = env, clientId = "flais-keycloak-demo-telemark").use { resp ->
+    fun `client  with 1 org directly to flais-org-idp-selector`(env: KcEnvironment) {
+        openAuthUrl(env = env, clientId = Clients.FLAIS_KEYCLOAK_DEMO_TELEMARK).use { resp ->
             assertEquals(200, resp.code)
 
             val html = resp.body.string()
             val kc = KcContextParser.parseKcContext(html)
 
-            assertEquals("flais-org-idp-selector", kc.pageId)
+            assertEquals(Pages.FLAIS_ORG_IDP_SELECTOR, kc.pageId)
         }
     }
 
     @Test
-    fun `client (flais-keycloak-demo-entra) dont return org idporten`(env: KcEnvironment) {
-        openAuthUrl(env = env, clientId = "flais-keycloak-demo-entra").use { resp ->
+    fun `client dont return org idporten`(env: KcEnvironment) {
+        openAuthUrl(env = env, clientId = Clients.FLAIS_KEYCLOAK_DEMO_ENTRA).use { resp ->
             assertEquals(200, resp.code)
 
             val html = resp.body.string()
             val kc = KcContextParser.parseKcContext(html)
 
-            assertFalse(kc.organizations!!.map { it.alias }.contains("idporten"))
+            assertFalse(kc.organizations!!.map { it.alias }.contains(Orgs.IDPORTEN))
         }
     }
 }

--- a/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/clients/PublicClientMapperTest.kt
+++ b/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/clients/PublicClientMapperTest.kt
@@ -7,6 +7,7 @@ import no.novari.test.common.fixture.TestStrings.Idps
 import no.novari.test.common.fixture.TestStrings.Orgs
 import no.novari.test.common.fixture.TestStrings.Realms
 import no.novari.test.common.fixture.TestStrings.Scopes
+import no.novari.test.common.fixture.TestStrings.Uris
 import no.novari.test.common.fixture.TestStrings.Users
 import no.novari.test.common.utils.KcUrl
 import no.novari.test.integration.utils.KcFlow.loginWithUser
@@ -25,7 +26,7 @@ class PublicClientMapperTest {
         val client = KcHttpClient.create(followRedirects = true)
         val realm = Realms.EXTERNAL
         val clientId = Clients.FLAIS_KEYCLOAK_DEMO
-        val redirectUri = "${env.flaisKeycloakDemoUrl()}/callback"
+        val redirectUri = Uris.redirectCallback(env.flaisKeycloakDemoUrl())
         val scope = Scopes.PROFILE_EMAIL
         val orgAlias = Orgs.TELEMARK
         val idpAlias = Idps.ENTRA_TELEMARK

--- a/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/clients/PublicClientMapperTest.kt
+++ b/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/clients/PublicClientMapperTest.kt
@@ -1,8 +1,14 @@
 package no.novari.test.integration.application.clients
 
-import no.novari.test.common.extensions.kc.KcEnvExtension
-import no.novari.test.common.utils.kc.KcEnvironment
-import no.novari.test.common.utils.kc.KcUrl
+import no.novari.test.common.environment.kc.KcEnvironment
+import no.novari.test.common.environment.kc.KcEnvironmentExtension
+import no.novari.test.common.fixture.TestStrings.Clients
+import no.novari.test.common.fixture.TestStrings.Idps
+import no.novari.test.common.fixture.TestStrings.Orgs
+import no.novari.test.common.fixture.TestStrings.Realms
+import no.novari.test.common.fixture.TestStrings.Scopes
+import no.novari.test.common.fixture.TestStrings.Users
+import no.novari.test.common.utils.KcUrl
 import no.novari.test.integration.utils.KcFlow.loginWithUser
 import no.novari.test.integration.utils.KcHttpClient
 import no.novari.test.integration.utils.KcToken
@@ -12,19 +18,19 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertNotNull
 import org.junit.jupiter.api.extension.ExtendWith
 
-@ExtendWith(KcEnvExtension::class)
+@ExtendWith(KcEnvironmentExtension::class)
 class PublicClientMapperTest {
     @Test
     fun `map_roles_to_token maps roles correctly to access token`(env: KcEnvironment) {
         val client = KcHttpClient.create(followRedirects = true)
-        val realm = "external"
-        val clientId = "flais-keycloak-demo"
+        val realm = Realms.EXTERNAL
+        val clientId = Clients.FLAIS_KEYCLOAK_DEMO
         val redirectUri = "${env.flaisKeycloakDemoUrl()}/callback"
-        val scope = "openid profile email"
-        val orgAlias = "telemark"
-        val idpAlias = "entra-telemark"
-        val email = "alice.basic@telemark.no"
-        val password = "password"
+        val scope = Scopes.PROFILE_EMAIL
+        val orgAlias = Orgs.TELEMARK
+        val idpAlias = Idps.ENTRA_TELEMARK
+        val username = Users.ALICE_TELEMARK
+        val password = Users.PASSWORD
         val (authUrl, codeVerifier) =
             KcUrl.authUrl(
                 env = env,
@@ -39,7 +45,7 @@ class PublicClientMapperTest {
             clientId,
             orgAlias,
             idpAlias,
-            email,
+            username,
             password,
             client,
             authUrl,

--- a/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/clients/PublicClientTokenTest.kt
+++ b/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/clients/PublicClientTokenTest.kt
@@ -1,8 +1,14 @@
 package no.novari.test.integration.application.clients
 
-import no.novari.test.common.extensions.kc.KcEnvExtension
-import no.novari.test.common.utils.kc.KcEnvironment
-import no.novari.test.common.utils.kc.KcUrl
+import no.novari.test.common.environment.kc.KcEnvironment
+import no.novari.test.common.environment.kc.KcEnvironmentExtension
+import no.novari.test.common.fixture.TestStrings.Clients
+import no.novari.test.common.fixture.TestStrings.Idps
+import no.novari.test.common.fixture.TestStrings.Orgs
+import no.novari.test.common.fixture.TestStrings.Realms
+import no.novari.test.common.fixture.TestStrings.Scopes
+import no.novari.test.common.fixture.TestStrings.Users
+import no.novari.test.common.utils.KcUrl
 import no.novari.test.integration.utils.KcFlow.loginWithUser
 import no.novari.test.integration.utils.KcHttpClient
 import no.novari.test.integration.utils.KcToken.exchangeCodeForAccessToken
@@ -13,19 +19,19 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertNotNull
 import org.junit.jupiter.api.extension.ExtendWith
 
-@ExtendWith(KcEnvExtension::class)
+@ExtendWith(KcEnvironmentExtension::class)
 class PublicClientTokenTest {
     @Test
     fun `code flow returns valid access token`(env: KcEnvironment) {
         val client = KcHttpClient.create(followRedirects = true)
-        val realm = "external"
-        val clientId = "flais-keycloak-demo"
+        val realm = Realms.EXTERNAL
+        val clientId = Clients.FLAIS_KEYCLOAK_DEMO
         val redirectUri = "${env.flaisKeycloakDemoUrl()}/callback"
-        val scope = "openid profile email"
-        val orgAlias = "telemark"
-        val idpAlias = "entra-telemark"
-        val email = "alice.basic@telemark.no"
-        val password = "password"
+        val scope = Scopes.PROFILE_EMAIL
+        val orgAlias = Orgs.TELEMARK
+        val idpAlias = Idps.ENTRA_TELEMARK
+        val username = Users.ALICE_TELEMARK
+        val password = Users.PASSWORD
         val (authUrl, codeVerifier) =
             KcUrl.authUrl(
                 env = env,
@@ -40,7 +46,7 @@ class PublicClientTokenTest {
             clientId,
             orgAlias,
             idpAlias,
-            email,
+            username,
             password,
             client,
             authUrl,

--- a/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/clients/PublicClientTokenTest.kt
+++ b/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/clients/PublicClientTokenTest.kt
@@ -7,6 +7,7 @@ import no.novari.test.common.fixture.TestStrings.Idps
 import no.novari.test.common.fixture.TestStrings.Orgs
 import no.novari.test.common.fixture.TestStrings.Realms
 import no.novari.test.common.fixture.TestStrings.Scopes
+import no.novari.test.common.fixture.TestStrings.Uris
 import no.novari.test.common.fixture.TestStrings.Users
 import no.novari.test.common.utils.KcUrl
 import no.novari.test.integration.utils.KcFlow.loginWithUser
@@ -26,7 +27,7 @@ class PublicClientTokenTest {
         val client = KcHttpClient.create(followRedirects = true)
         val realm = Realms.EXTERNAL
         val clientId = Clients.FLAIS_KEYCLOAK_DEMO
-        val redirectUri = "${env.flaisKeycloakDemoUrl()}/callback"
+        val redirectUri = Uris.redirectCallback(env.flaisKeycloakDemoUrl())
         val scope = Scopes.PROFILE_EMAIL
         val orgAlias = Orgs.TELEMARK
         val idpAlias = Idps.ENTRA_TELEMARK

--- a/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/flows/FlaisBrowserFlowTest.kt
+++ b/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/flows/FlaisBrowserFlowTest.kt
@@ -1,7 +1,11 @@
 package no.novari.test.integration.application.flows
 
-import no.novari.test.common.extensions.kc.KcEnvExtension
-import no.novari.test.common.utils.kc.KcEnvironment
+import no.novari.test.common.environment.kc.KcEnvironment
+import no.novari.test.common.environment.kc.KcEnvironmentExtension
+import no.novari.test.common.fixture.TestStrings.Clients
+import no.novari.test.common.fixture.TestStrings.Idps
+import no.novari.test.common.fixture.TestStrings.Orgs
+import no.novari.test.common.fixture.TestStrings.Users
 import no.novari.test.integration.utils.KcFlow.loginWithUser
 import no.novari.test.integration.utils.KcFlow.openAuthUrl
 import no.novari.test.integration.utils.KcHttpClient
@@ -10,17 +14,17 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertNotNull
 import org.junit.jupiter.api.extension.ExtendWith
 
-@ExtendWith(KcEnvExtension::class)
+@ExtendWith(KcEnvironmentExtension::class)
 class FlaisBrowserFlowTest {
-    private val email = "alice.basic@telemark.no"
-    private val password = "password"
-    private val clientId = "flais-keycloak-demo"
-    private val orgAlias = "telemark"
-    private val idpAlias = "entra-telemark"
+    private val username = Users.ALICE_TELEMARK
+    private val password = Users.PASSWORD
+    private val clientId = Clients.FLAIS_KEYCLOAK_DEMO
+    private val orgAlias = Orgs.TELEMARK
+    private val idpAlias = Idps.ENTRA_TELEMARK
 
     @Test
     fun `flow returns code after login`(env: KcEnvironment) {
-        loginWithUser(env, clientId, orgAlias, idpAlias, email, password).use { resp ->
+        loginWithUser(env, clientId, orgAlias, idpAlias, username, password).use { resp ->
             assertEquals(200, resp.code)
 
             assertNotNull(resp.request.url.queryParameter("code"))
@@ -31,7 +35,7 @@ class FlaisBrowserFlowTest {
     fun `with SSO cookie, org and idp selector is skipped and returns code after login`(env: KcEnvironment) {
         val client = KcHttpClient.create(followRedirects = true)
 
-        loginWithUser(env, clientId, orgAlias, idpAlias, email, password, client).use { resp ->
+        loginWithUser(env, clientId, orgAlias, idpAlias, username, password, client).use { resp ->
             assertEquals(200, resp.code)
 
             openAuthUrl(env = env, clientId = clientId, httpClient = client).use { resp ->

--- a/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/flows/FlaisFirstBrokerLoginFlowTest.kt
+++ b/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/flows/FlaisFirstBrokerLoginFlowTest.kt
@@ -1,9 +1,14 @@
 package no.novari.test.integration.application.flows
 
 import no.novari.test.common.config.KcConfig
-import no.novari.test.common.extensions.kc.KcEnvExtension
-import no.novari.test.common.utils.kc.KcAdminClient
-import no.novari.test.common.utils.kc.KcEnvironment
+import no.novari.test.common.environment.kc.KcEnvironment
+import no.novari.test.common.environment.kc.KcEnvironmentExtension
+import no.novari.test.common.fixture.TestStrings.Clients
+import no.novari.test.common.fixture.TestStrings.Idps
+import no.novari.test.common.fixture.TestStrings.Orgs
+import no.novari.test.common.fixture.TestStrings.Realms
+import no.novari.test.common.fixture.TestStrings.Users
+import no.novari.test.common.utils.KcAdminClient
 import no.novari.test.integration.utils.KcFlow.loginWithUser
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -14,15 +19,14 @@ import org.junit.jupiter.api.assertNotNull
 import org.junit.jupiter.api.assertNull
 import org.junit.jupiter.api.extension.ExtendWith
 
-@ExtendWith(KcEnvExtension::class)
+@ExtendWith(KcEnvironmentExtension::class)
 class FlaisFirstBrokerLoginFlowTest {
-    private val realm = "external"
-    private val email = "alice.basic@telemark.no"
-    private val username = "alice.basic@telemark.no"
-    private val firstname = "Alice"
-    private val lastname = "Basic"
-    private val password = "password"
-    private val clientId = "flais-keycloak-demo"
+    private val realm = Realms.EXTERNAL
+    private val username = Users.ALICE_TELEMARK
+    private val firstname = Users.ALICE_FIRST_NAME
+    private val lastname = Users.BASIC_LAST_NAME
+    private val password = Users.PASSWORD
+    private val clientId = Clients.FLAIS_KEYCLOAK_DEMO
 
     @BeforeEach
     fun setUp(env: KcEnvironment) {
@@ -31,27 +35,27 @@ class FlaisFirstBrokerLoginFlowTest {
             KcAdminClient
                 .findUserByUsername(
                     realmRes,
-                    email,
+                    username,
                 )?.let { KcAdminClient.deleteUser(realmRes, it.id) }
 
-            assertNull(KcAdminClient.findUserByUsername(realmRes, email))
+            assertNull(KcAdminClient.findUserByUsername(realmRes, username))
         }
     }
 
     @Test
-    fun `first login to org (telemark) creates user with correct idp and org`(
+    fun `first login to org creates user with correct idp and org`(
         env: KcEnvironment,
         kcConfig: KcConfig,
     ) {
-        val orgAlias = "telemark"
-        val idpAlias = "entra-telemark"
+        val orgAlias = Orgs.TELEMARK
+        val idpAlias = Idps.ENTRA_TELEMARK
         val (kc, realmRes) = KcAdminClient.connect(env, realm)
 
         kc.use {
-            loginWithUser(env, clientId, orgAlias, idpAlias, email, password).use { resp ->
+            loginWithUser(env, clientId, orgAlias, idpAlias, username, password).use { resp ->
                 assertEquals(200, resp.code)
 
-                val user = KcAdminClient.findUserByUsername(realmRes, email)
+                val user = KcAdminClient.findUserByUsername(realmRes, username)
                 assertNotNull(user)
 
                 val member =
@@ -73,16 +77,16 @@ class FlaisFirstBrokerLoginFlowTest {
     }
 
     @Test
-    fun `login to org (telemark) with existing user without idp, links idp to user`(
+    fun `login to org with existing user without idp, links idp to user`(
         env: KcEnvironment,
         kcConfig: KcConfig,
     ) {
-        val orgAlias = "telemark"
-        val idpAlias = "entra-telemark"
+        val orgAlias = Orgs.TELEMARK
+        val idpAlias = Idps.ENTRA_TELEMARK
         val (kc, realmRes) = KcAdminClient.connect(env, realm)
 
         kc.use {
-            val userId = KcAdminClient.createUser(realmRes, username, email, firstname, lastname)
+            val userId = KcAdminClient.createUser(realmRes, username, username, firstname, lastname)
             assertNotNull(userId)
 
             val links = KcAdminClient.getFederatedIdentities(realmRes, userId)
@@ -94,10 +98,10 @@ class FlaisFirstBrokerLoginFlowTest {
 
             KcAdminClient.addUserToOrg(realmRes, userId, kcConfig.requireOrg(orgAlias).id)
 
-            loginWithUser(env, clientId, orgAlias, idpAlias, email, password).use { resp ->
+            loginWithUser(env, clientId, orgAlias, idpAlias, username, password).use { resp ->
                 assertEquals(200, resp.code)
 
-                val user = KcAdminClient.findUserByUsername(realmRes, email)
+                val user = KcAdminClient.findUserByUsername(realmRes, username)
                 assertNotNull(user)
 
                 val links = KcAdminClient.getFederatedIdentities(realmRes, user.id)
@@ -111,25 +115,25 @@ class FlaisFirstBrokerLoginFlowTest {
     }
 
     @Test
-    fun `login to org (telemark) with existing user without membership, links org and idp to user`(
+    fun `login to org with existing user without membership, links org and idp to user`(
         env: KcEnvironment,
         kcConfig: KcConfig,
     ) {
-        val orgAlias = "telemark"
-        val idpAlias = "entra-telemark"
+        val orgAlias = Orgs.TELEMARK
+        val idpAlias = Idps.ENTRA_TELEMARK
         val (kc, realmRes) = KcAdminClient.connect(env, realm)
 
         kc.use {
-            val userId = KcAdminClient.createUser(realmRes, username, email, firstname, lastname)
+            val userId = KcAdminClient.createUser(realmRes, username, username, firstname, lastname)
             assertNotNull(userId)
 
             val member = KcAdminClient.getOrgMember(realmRes, kcConfig.requireOrg(orgAlias).id, userId)
             assertNull(member)
 
-            loginWithUser(env, clientId, orgAlias, idpAlias, email, password).use { resp ->
+            loginWithUser(env, clientId, orgAlias, idpAlias, username, password).use { resp ->
                 assertEquals(200, resp.code)
 
-                val user = KcAdminClient.findUserByUsername(realmRes, email)
+                val user = KcAdminClient.findUserByUsername(realmRes, username)
                 assertNotNull(user)
 
                 val member =

--- a/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/idp/EntraMapperTest.kt
+++ b/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/idp/EntraMapperTest.kt
@@ -1,31 +1,36 @@
 package no.novari.test.integration.application.idp
 
-import no.novari.test.common.extensions.kc.KcEnvExtension
-import no.novari.test.common.utils.kc.KcAdminClient
-import no.novari.test.common.utils.kc.KcEnvironment
+import no.novari.test.common.environment.kc.KcEnvironment
+import no.novari.test.common.environment.kc.KcEnvironmentExtension
+import no.novari.test.common.fixture.TestStrings.Clients
+import no.novari.test.common.fixture.TestStrings.Idps
+import no.novari.test.common.fixture.TestStrings.Orgs
+import no.novari.test.common.fixture.TestStrings.Realms
+import no.novari.test.common.fixture.TestStrings.Users
+import no.novari.test.common.utils.KcAdminClient
 import no.novari.test.integration.utils.KcFlow.loginWithUser
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
-@ExtendWith(KcEnvExtension::class)
+@ExtendWith(KcEnvironmentExtension::class)
 class EntraMapperTest {
     @Test
     fun `map_roles_to_user_attribute maps roles from claim to attribute`(env: KcEnvironment) {
-        val realm = "external"
-        val email = "alice.basic@telemark.no"
-        val password = "password"
-        val clientId = "flais-keycloak-demo"
-        val orgAlias = "telemark"
-        val idpAlias = "entra-telemark"
+        val realm = Realms.EXTERNAL
+        val username = Users.ALICE_TELEMARK
+        val password = Users.PASSWORD
+        val clientId = Clients.FLAIS_KEYCLOAK_DEMO
+        val orgAlias = Orgs.TELEMARK
+        val idpAlias = Idps.ENTRA_TELEMARK
 
-        loginWithUser(env, clientId, orgAlias, idpAlias, email, password).use { resp ->
+        loginWithUser(env, clientId, orgAlias, idpAlias, username, password).use { resp ->
             assertEquals(200, resp.code)
 
             val (kc, realmRes) = KcAdminClient.connect(env, realm)
 
             kc.use {
-                val user = KcAdminClient.findUserByUsername(realmRes, email)
+                val user = KcAdminClient.findUserByUsername(realmRes, username)
                 assertEquals(listOf("read", "write", "admin"), user?.attributes["roles"])
             }
         }

--- a/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/kc/KcConfigTest.kt
+++ b/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/kc/KcConfigTest.kt
@@ -1,14 +1,18 @@
 package no.novari.test.integration.application.kc
 
 import no.novari.test.common.config.KcConfig
-import no.novari.test.common.extensions.kc.KcEnvExtension
+import no.novari.test.common.environment.kc.KcEnvironmentExtension
+import no.novari.test.common.fixture.TestStrings.Clients
+import no.novari.test.common.fixture.TestStrings.Idps
+import no.novari.test.common.fixture.TestStrings.Orgs
+import no.novari.test.common.fixture.TestStrings.Realms
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
-@ExtendWith(KcEnvExtension::class)
+@ExtendWith(KcEnvironmentExtension::class)
 class KcConfigTest {
     private val commonRedirectUris = listOf("http://localhost*")
     private val commonWebOrigins = listOf("*")
@@ -26,7 +30,7 @@ class KcConfigTest {
 
     @Test
     fun `realm name should be external`(kcConfig: KcConfig) {
-        assertEquals("external", kcConfig.realmName)
+        assertEquals(Realms.EXTERNAL, kcConfig.realmName)
     }
 
     @Test
@@ -34,7 +38,7 @@ class KcConfigTest {
         assertTrue(
             kcConfig
                 .orgAliases()
-                .containsAll(listOf("idporten", "innlandet", "telemark", "rogaland")),
+                .containsAll(listOf(Orgs.IDPORTEN, Orgs.INNLANDET, Orgs.TELEMARK, Orgs.ROGALAND)),
         )
     }
 
@@ -43,7 +47,7 @@ class KcConfigTest {
         assertTrue(
             kcConfig
                 .idpAliases()
-                .containsAll(listOf("entra-telemark", "entra-telemark-alt", "idporten", "entra-rogaland")),
+                .containsAll(listOf(Idps.ENTRA_TELEMARK, Idps.ENTRA_TELEMARK_ALT, Idps.IDPORTEN, Idps.ENTRA_ROGALAND)),
         )
     }
 
@@ -51,19 +55,19 @@ class KcConfigTest {
 
     @Test
     fun `idp aliases for idporten org should be idporten only`(kcConfig: KcConfig) {
-        assertEquals(listOf("idporten"), kcConfig.idpAliasesForOrg("idporten"))
+        assertEquals(listOf(Idps.IDPORTEN), kcConfig.idpAliasesForOrg(Orgs.IDPORTEN))
     }
 
     @Test
     fun `innlandet should have no idps`(kcConfig: KcConfig) {
-        assertTrue(kcConfig.idpAliasesForOrg("innlandet").isEmpty())
+        assertTrue(kcConfig.idpAliasesForOrg(Orgs.INNLANDET).isEmpty())
     }
 
     @Test
     fun `telemark should have expected idps and not idporten`(kcConfig: KcConfig) {
-        assertTrue(kcConfig.orgHasIdp("telemark", "entra-telemark"))
-        assertTrue(kcConfig.orgHasIdp("telemark", "entra-telemark-alt"))
-        assertFalse(kcConfig.orgHasIdp("telemark", "idporten"))
+        assertTrue(kcConfig.orgHasIdp(Orgs.TELEMARK, Idps.ENTRA_TELEMARK))
+        assertTrue(kcConfig.orgHasIdp(Orgs.TELEMARK, Idps.ENTRA_TELEMARK_ALT))
+        assertFalse(kcConfig.orgHasIdp(Orgs.TELEMARK, Idps.IDPORTEN))
     }
 
     // --- Client ID set --------------------------------------------------------
@@ -73,11 +77,12 @@ class KcConfigTest {
         assertTrue(
             kcConfig.clientIds().containsAll(
                 listOf(
-                    "flais-keycloak-demo",
-                    "flais-keycloak-demo-telemark",
-                    "flais-keycloak-demo-idporten",
-                    "flais-keycloak-demo-invalid",
-                    "flais-keycloak-demo-entra",
+                    Clients.FLAIS_KEYCLOAK_DEMO,
+                    Clients.FLAIS_KEYCLOAK_DEMO_TELEMARK,
+                    Clients.FLAIS_KEYCLOAK_DEMO_IDPORTEN,
+                    Clients.FLAIS_KEYCLOAK_DEMO_INVALID,
+                    Clients.FLAIS_KEYCLOAK_DEMO_ENTRA,
+                    Clients.FLAIS_KEYCLOAK_DEMO_NOT_TELEMARK,
                 ),
             ),
         )
@@ -87,7 +92,7 @@ class KcConfigTest {
 
     @Test
     fun `flais-keycloak-demo should have common flags and empty attributes`(kcConfig: KcConfig) {
-        kcConfig.requireClient("flais-keycloak-demo").also { c ->
+        kcConfig.requireClient(Clients.FLAIS_KEYCLOAK_DEMO).also { c ->
             assertCommonFlags(c)
             assertEquals(emptyMap<String, String>(), c.attributes)
         }
@@ -95,10 +100,10 @@ class KcConfigTest {
 
     @Test
     fun `flais-keycloak-demo-telemark should have common flags and telemark whitelisted`(kcConfig: KcConfig) {
-        kcConfig.requireClient("flais-keycloak-demo-telemark").also { c ->
+        kcConfig.requireClient(Clients.FLAIS_KEYCLOAK_DEMO_TELEMARK).also { c ->
             assertCommonFlags(c)
             assertEquals(
-                mapOf("permission.whitelisted.organizations" to "telemark"),
+                mapOf("permission.whitelisted.organizations" to Orgs.TELEMARK),
                 c.attributes,
             )
         }
@@ -106,10 +111,10 @@ class KcConfigTest {
 
     @Test
     fun `flais-keycloak-demo-idporten should have common flags and idporten whitelisted`(kcConfig: KcConfig) {
-        kcConfig.requireClient("flais-keycloak-demo-idporten").also { c ->
+        kcConfig.requireClient(Clients.FLAIS_KEYCLOAK_DEMO_IDPORTEN).also { c ->
             assertCommonFlags(c)
             assertEquals(
-                mapOf("permission.whitelisted.organizations" to "idporten"),
+                mapOf("permission.whitelisted.organizations" to Orgs.IDPORTEN),
                 c.attributes,
             )
         }
@@ -117,10 +122,10 @@ class KcConfigTest {
 
     @Test
     fun `flais-keycloak-demo-entra should have common flags and idporten blacklisted`(kcConfig: KcConfig) {
-        kcConfig.requireClient("flais-keycloak-demo-entra").also { c ->
+        kcConfig.requireClient(Clients.FLAIS_KEYCLOAK_DEMO_ENTRA).also { c ->
             assertCommonFlags(c)
             assertEquals(
-                mapOf("permission.blacklisted.organizations" to "idporten"),
+                mapOf("permission.blacklisted.organizations" to Orgs.IDPORTEN),
                 c.attributes,
             )
         }
@@ -128,10 +133,10 @@ class KcConfigTest {
 
     @Test
     fun `flais-keycloak-demo-invalid should have common flags and invalid-org whitelist`(kcConfig: KcConfig) {
-        kcConfig.requireClient("flais-keycloak-demo-invalid").also { c ->
+        kcConfig.requireClient(Clients.FLAIS_KEYCLOAK_DEMO_INVALID).also { c ->
             assertCommonFlags(c)
             assertEquals(
-                mapOf("permission.whitelisted.organizations" to "invalid-org"),
+                mapOf("permission.whitelisted.organizations" to Orgs.INVALID),
                 c.attributes,
             )
         }

--- a/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/kc/KcHealthTest.kt
+++ b/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/kc/KcHealthTest.kt
@@ -1,14 +1,14 @@
 package no.novari.test.integration.application.kc
 
-import no.novari.test.common.extensions.kc.KcEnvExtension
-import no.novari.test.common.utils.kc.KcEnvironment
+import no.novari.test.common.environment.kc.KcEnvironment
+import no.novari.test.common.environment.kc.KcEnvironmentExtension
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
-@ExtendWith(KcEnvExtension::class)
+@ExtendWith(KcEnvironmentExtension::class)
 class KcHealthTest {
     private val client = OkHttpClient()
 

--- a/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/mapper/OrgSpecificAttributeMapperTest.kt
+++ b/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/mapper/OrgSpecificAttributeMapperTest.kt
@@ -8,6 +8,7 @@ import no.novari.test.common.fixture.TestStrings.Idps
 import no.novari.test.common.fixture.TestStrings.Orgs
 import no.novari.test.common.fixture.TestStrings.Realms
 import no.novari.test.common.fixture.TestStrings.Scopes
+import no.novari.test.common.fixture.TestStrings.Uris
 import no.novari.test.common.fixture.TestStrings.Users
 import no.novari.test.common.utils.KcUrl
 import no.novari.test.integration.utils.KcFlow.loginWithUser
@@ -32,7 +33,7 @@ class OrgSpecificAttributeMapperTest {
         val client = KcHttpClient.create(followRedirects = true)
         val realm = Realms.EXTERNAL
         val clientId = Clients.FLAIS_KEYCLOAK_DEMO
-        val redirectUri = "${env.flaisKeycloakDemoUrl()}/callback"
+        val redirectUri = Uris.redirectCallback(env.flaisKeycloakDemoUrl())
         val scope = Scopes.PROFILE_EMAIL_ORGANIZATION
         val idpAlias = Idps.entra(orgAlias)
         val username = Users.alice(orgAlias)

--- a/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/mapper/OrgSpecificAttributeMapperTest.kt
+++ b/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/mapper/OrgSpecificAttributeMapperTest.kt
@@ -1,9 +1,15 @@
 package no.novari.test.integration.application.mapper
 
 import no.novari.test.common.config.KcConfig
-import no.novari.test.common.extensions.kc.KcEnvExtension
-import no.novari.test.common.utils.kc.KcEnvironment
-import no.novari.test.common.utils.kc.KcUrl
+import no.novari.test.common.environment.kc.KcEnvironment
+import no.novari.test.common.environment.kc.KcEnvironmentExtension
+import no.novari.test.common.fixture.TestStrings.Clients
+import no.novari.test.common.fixture.TestStrings.Idps
+import no.novari.test.common.fixture.TestStrings.Orgs
+import no.novari.test.common.fixture.TestStrings.Realms
+import no.novari.test.common.fixture.TestStrings.Scopes
+import no.novari.test.common.fixture.TestStrings.Users
+import no.novari.test.common.utils.KcUrl
 import no.novari.test.integration.utils.KcFlow.loginWithUser
 import no.novari.test.integration.utils.KcHttpClient
 import no.novari.test.integration.utils.KcToken
@@ -14,23 +20,23 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
-@ExtendWith(KcEnvExtension::class)
+@ExtendWith(KcEnvironmentExtension::class)
 class OrgSpecificAttributeMapperTest {
     @ParameterizedTest(name = "org-specific-attribute-mapper for org ({0}) maps correctly ")
-    @ValueSource(strings = ["telemark", "rogaland"])
+    @ValueSource(strings = [Orgs.TELEMARK, Orgs.ROGALAND])
     fun `org-specific-attribute-mapper maps attribute correctly to access token`(
         orgAlias: String,
         env: KcEnvironment,
         kcConfig: KcConfig,
     ) {
         val client = KcHttpClient.create(followRedirects = true)
-        val realm = "external"
-        val clientId = "flais-keycloak-demo"
+        val realm = Realms.EXTERNAL
+        val clientId = Clients.FLAIS_KEYCLOAK_DEMO
         val redirectUri = "${env.flaisKeycloakDemoUrl()}/callback"
-        val scope = "openid profile email organization"
-        val idpAlias = "entra-$orgAlias"
-        val email = "alice.basic@$orgAlias.no"
-        val password = "password"
+        val scope = Scopes.PROFILE_EMAIL_ORGANIZATION
+        val idpAlias = Idps.entra(orgAlias)
+        val username = Users.alice(orgAlias)
+        val password = Users.PASSWORD
         val (authUrl, codeVerifier) =
             KcUrl.authUrl(
                 env = env,
@@ -45,11 +51,11 @@ class OrgSpecificAttributeMapperTest {
             clientId,
             orgAlias,
             idpAlias,
-            email,
+            username,
             password,
             client,
             authUrl,
-            hasIdpSelector = (orgAlias == "telemark"),
+            hasIdpSelector = (orgAlias == Orgs.TELEMARK),
         ).use { resp ->
             assertEquals(200, resp.code)
 

--- a/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/mapper/QlikRolesMapperTest.kt
+++ b/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/mapper/QlikRolesMapperTest.kt
@@ -1,9 +1,15 @@
 package no.novari.test.integration.application.mapper
 
-import no.novari.test.common.extensions.kc.KcEnvExtension
-import no.novari.test.common.utils.kc.KcAdminClient
-import no.novari.test.common.utils.kc.KcEnvironment
-import no.novari.test.common.utils.kc.KcUrl
+import no.novari.test.common.environment.kc.KcEnvironment
+import no.novari.test.common.environment.kc.KcEnvironmentExtension
+import no.novari.test.common.fixture.TestStrings.Clients
+import no.novari.test.common.fixture.TestStrings.Idps
+import no.novari.test.common.fixture.TestStrings.Orgs
+import no.novari.test.common.fixture.TestStrings.Realms
+import no.novari.test.common.fixture.TestStrings.Scopes
+import no.novari.test.common.fixture.TestStrings.Users
+import no.novari.test.common.utils.KcAdminClient
+import no.novari.test.common.utils.KcUrl
 import no.novari.test.integration.utils.KcFlow.loginWithUser
 import no.novari.test.integration.utils.KcHttpClient
 import no.novari.test.integration.utils.KcToken
@@ -14,23 +20,23 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
-@ExtendWith(KcEnvExtension::class)
+@ExtendWith(KcEnvironmentExtension::class)
 class QlikRolesMapperTest {
-    val realm = "external"
-    val clientId = "qlik"
-    val scope = "openid profile email"
-    val password = "password"
+    val realm = Realms.EXTERNAL
+    val clientId = Clients.QLIK
+    val scope = Scopes.PROFILE_EMAIL
+    val password = Users.PASSWORD
 
     @ParameterizedTest(name = "qlik-roles-mapper for org ({0}) maps correctly ")
-    @ValueSource(strings = ["telemark", "rogaland"])
+    @ValueSource(strings = [Orgs.TELEMARK, Orgs.ROGALAND])
     fun `qlik-mapper maps attribute correctly to access token`(
         orgAlias: String,
         env: KcEnvironment,
     ) {
         val client = KcHttpClient.create(followRedirects = true)
         val redirectUri = "${env.flaisKeycloakDemoUrl()}/callback"
-        val idpAlias = "entra-$orgAlias"
-        val email = "qlik.basic@$orgAlias.no"
+        val idpAlias = Idps.entra(orgAlias)
+        val username = Users.qlikBasic(orgAlias)
         val (authUrl, codeVerifier) =
             KcUrl.authUrl(
                 env = env,
@@ -57,11 +63,11 @@ class QlikRolesMapperTest {
             clientId,
             orgAlias,
             idpAlias,
-            email,
+            username,
             password,
             client,
             authUrl,
-            hasIdpSelector = (orgAlias == "telemark"),
+            hasIdpSelector = (orgAlias == Orgs.TELEMARK),
         ).use { resp ->
             assertEquals(200, resp.code)
 
@@ -106,15 +112,15 @@ class QlikRolesMapperTest {
     }
 
     @ParameterizedTest(name = "qlik-roles-mapper for org ({0}) for passthrough counties maps correctly`")
-    @ValueSource(strings = ["telemark", "rogaland"])
+    @ValueSource(strings = [Orgs.TELEMARK, Orgs.ROGALAND])
     fun `qlik-roles-mapper for passthrough counties maps correctly to access token`(
         orgAlias: String,
         env: KcEnvironment,
     ) {
         val client = KcHttpClient.create(followRedirects = true)
         val redirectUri = "${env.flaisKeycloakDemoUrl()}/callback"
-        val idpAlias = "entra-$orgAlias"
-        val email = "qlik.basic@$orgAlias.no"
+        val idpAlias = Idps.entra(orgAlias)
+        val username = Users.qlikBasic(orgAlias)
         val (authUrl, codeVerifier) =
             KcUrl.authUrl(
                 env = env,
@@ -141,11 +147,11 @@ class QlikRolesMapperTest {
             clientId,
             orgAlias,
             idpAlias,
-            email,
+            username,
             password,
             client,
             authUrl,
-            hasIdpSelector = (orgAlias == "telemark"),
+            hasIdpSelector = (orgAlias == Orgs.TELEMARK),
         ).use { resp ->
             assertEquals(200, resp.code)
 
@@ -179,8 +185,8 @@ class QlikRolesMapperTest {
 
     private fun getCounty(orgAlias: String): String {
         return when (orgAlias) {
-            "telemark" -> "1"
-            "rogaland" -> "22"
+            Orgs.TELEMARK -> "1"
+            Orgs.ROGALAND -> "22"
             else -> throw IllegalArgumentException("Unknown orgAlias: $orgAlias")
         }
     }

--- a/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/mapper/QlikRolesMapperTest.kt
+++ b/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/mapper/QlikRolesMapperTest.kt
@@ -7,6 +7,7 @@ import no.novari.test.common.fixture.TestStrings.Idps
 import no.novari.test.common.fixture.TestStrings.Orgs
 import no.novari.test.common.fixture.TestStrings.Realms
 import no.novari.test.common.fixture.TestStrings.Scopes
+import no.novari.test.common.fixture.TestStrings.Uris
 import no.novari.test.common.fixture.TestStrings.Users
 import no.novari.test.common.utils.KcAdminClient
 import no.novari.test.common.utils.KcUrl
@@ -34,7 +35,7 @@ class QlikRolesMapperTest {
         env: KcEnvironment,
     ) {
         val client = KcHttpClient.create(followRedirects = true)
-        val redirectUri = "${env.flaisKeycloakDemoUrl()}/callback"
+        val redirectUri = Uris.redirectCallback(env.flaisKeycloakDemoUrl())
         val idpAlias = Idps.entra(orgAlias)
         val username = Users.qlikBasic(orgAlias)
         val (authUrl, codeVerifier) =
@@ -118,7 +119,7 @@ class QlikRolesMapperTest {
         env: KcEnvironment,
     ) {
         val client = KcHttpClient.create(followRedirects = true)
-        val redirectUri = "${env.flaisKeycloakDemoUrl()}/callback"
+        val redirectUri = Uris.redirectCallback(env.flaisKeycloakDemoUrl())
         val idpAlias = Idps.entra(orgAlias)
         val username = Users.qlikBasic(orgAlias)
         val (authUrl, codeVerifier) =

--- a/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/scim/ComplianceTest.kt
+++ b/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/scim/ComplianceTest.kt
@@ -1,9 +1,12 @@
 package no.novari.test.integration.application.scim
 
 import no.novari.test.common.config.KcConfig
-import no.novari.test.common.extensions.kc.KcEnvExtension
-import no.novari.test.common.utils.kc.KcAdminClient
-import no.novari.test.common.utils.kc.KcEnvironment
+import no.novari.test.common.environment.kc.KcEnvironment
+import no.novari.test.common.environment.kc.KcEnvironmentExtension
+import no.novari.test.common.fixture.TestStrings.Orgs
+import no.novari.test.common.fixture.TestStrings.Realms
+import no.novari.test.common.fixture.TestStrings.Users
+import no.novari.test.common.utils.KcAdminClient
 import no.novari.test.integration.utils.ScimHttpClient
 import org.awaitility.Awaitility.await
 import org.awaitility.kotlin.withPollInterval
@@ -22,12 +25,12 @@ import java.nio.file.Paths
 import java.time.Duration
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@ExtendWith(KcEnvExtension::class)
+@ExtendWith(KcEnvironmentExtension::class)
 class ComplianceTest {
-    private val realm = "external"
+    private val realm = Realms.EXTERNAL
 
     @ParameterizedTest(name = "flais-scim-server for org ({0}) passes compliance tests")
-    @ValueSource(strings = ["telemark", "rogaland"])
+    @ValueSource(strings = [Orgs.TELEMARK, Orgs.ROGALAND])
     fun `flais-scim-server for org passes compliance tests`(
         orgAlias: String,
         env: KcEnvironment,
@@ -38,16 +41,15 @@ class ComplianceTest {
         val (kc, realmRes) = KcAdminClient.connect(env, realm)
 
         kc.use {
-            val email = "scimverify.user@$orgAlias.no"
-            val username = email
-            val firstname = "Scimverify"
-            val lastname = "User"
+            val username = Users.scimVerify(orgAlias)
+            val firstname = Users.SCIMVERIFY_FIRST_NAME
+            val lastname = Users.BASIC_LAST_NAME
 
             val userId =
                 KcAdminClient.createUser(
                     realmRes,
                     username,
-                    email,
+                    username,
                     firstname,
                     lastname,
                     realmRoleNames = listOf("scim-managed"),

--- a/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/scim/ProvisionTest.kt
+++ b/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/scim/ProvisionTest.kt
@@ -1,8 +1,10 @@
 package no.novari.test.integration.application.scim
 
 import no.novari.test.common.config.KcConfig
-import no.novari.test.common.extensions.kc.KcEnvExtension
-import no.novari.test.common.utils.kc.KcEnvironment
+import no.novari.test.common.environment.kc.KcEnvironment
+import no.novari.test.common.environment.kc.KcEnvironmentExtension
+import no.novari.test.common.fixture.TestStrings.Orgs
+import no.novari.test.common.fixture.TestStrings.Users
 import no.novari.test.integration.utils.ScimFlow
 import no.novari.test.integration.utils.ScimFlow.ScimUser
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -10,11 +12,11 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
-@ExtendWith(KcEnvExtension::class)
+@ExtendWith(KcEnvironmentExtension::class)
 class ProvisionTest {
     private val users =
         mapOf(
-            "telemark" to
+            Orgs.TELEMARK to
                 listOf(
                     ScimUser(
                         schemas =
@@ -23,16 +25,16 @@ class ProvisionTest {
                                 "urn:ietf:params:scim:schemas:extension:fint:2.0:User",
                             ),
                         externalId = "11111111-1111-1111-1111-111111111111",
-                        userName = "alice.basic@telemark.no",
+                        userName = Users.ALICE_TELEMARK,
                         active = true,
-                        name = ScimUser.Name("Alice", "Basic"),
-                        emails = listOf(ScimUser.Email("alice.basic@telemark.no", primary = true)),
+                        name = ScimUser.Name(Users.ALICE_FIRST_NAME, Users.BASIC_LAST_NAME),
+                        emails = listOf(ScimUser.Email(Users.ALICE_TELEMARK, primary = true)),
                         roles =
                             listOf(
                                 ScimUser.Role("read", "read", "WindowsAzureActiveDirectoryRole", false),
                                 ScimUser.Role("write", "write", "WindowsAzureActiveDirectoryRole", false),
                             ),
-                        fintUserExtension = ScimUser.FintUserExtension("1234", "1234", "alice.basic@telemark.no"),
+                        fintUserExtension = ScimUser.FintUserExtension("1234", "1234", Users.ALICE_TELEMARK),
                     ),
                     ScimUser(
                         schemas =
@@ -40,19 +42,19 @@ class ProvisionTest {
                                 "urn:ietf:params:scim:schemas:core:2.0:User",
                             ),
                         externalId = "22222222-2222-2222-2222-222222222222",
-                        userName = "jon.basic@telemark.no",
+                        userName = Users.JON_TELEMARK,
                         active = true,
-                        name = ScimUser.Name("Jon", "Basic"),
-                        emails = listOf(ScimUser.Email("jon.basic@telemark.no", primary = true)),
+                        name = ScimUser.Name(Users.JON_FIRST_NAME, Users.BASIC_LAST_NAME),
+                        emails = listOf(ScimUser.Email(Users.JON_TELEMARK, primary = true)),
                         roles =
                             listOf(
                                 ScimUser.Role("read", "read", "WindowsAzureActiveDirectoryRole", false),
                                 ScimUser.Role("write", "write", "WindowsAzureActiveDirectoryRole", false),
                             ),
-                        fintUserExtension = ScimUser.FintUserExtension("1234", "1234", "jon.basic@telemark.no"),
+                        fintUserExtension = ScimUser.FintUserExtension("1234", "1234", Users.JON_TELEMARK),
                     ),
                 ),
-            "rogaland" to
+            Orgs.ROGALAND to
                 listOf(
                     ScimUser(
                         schemas =
@@ -61,16 +63,16 @@ class ProvisionTest {
                                 "urn:ietf:params:scim:schemas:extension:fint:2.0:User",
                             ),
                         externalId = "11111111-1111-1111-1111-111111111111",
-                        userName = "alice.basic@rogaland.no",
+                        userName = Users.ALICE_ROGALAND,
                         active = true,
-                        name = ScimUser.Name("Alice", "Basic"),
-                        emails = listOf(ScimUser.Email("alice.basic@rogaland.no", primary = true)),
+                        name = ScimUser.Name(Users.ALICE_FIRST_NAME, Users.BASIC_LAST_NAME),
+                        emails = listOf(ScimUser.Email(Users.ALICE_ROGALAND, primary = true)),
                         roles =
                             listOf(
                                 ScimUser.Role("read", "read", "WindowsAzureActiveDirectoryRole", false),
                                 ScimUser.Role("write", "write", "WindowsAzureActiveDirectoryRole", false),
                             ),
-                        fintUserExtension = ScimUser.FintUserExtension("1234", "1234", "alice.basic@rogaland.no"),
+                        fintUserExtension = ScimUser.FintUserExtension("1234", "1234", Users.ALICE_ROGALAND),
                     ),
                     ScimUser(
                         schemas =
@@ -78,22 +80,22 @@ class ProvisionTest {
                                 "urn:ietf:params:scim:schemas:core:2.0:User",
                             ),
                         externalId = "22222222-2222-2222-2222-222222222222",
-                        userName = "jon.basic@rogaland.no",
+                        userName = Users.JON_ROGALAND,
                         active = true,
-                        name = ScimUser.Name("Jon", "Basic"),
-                        emails = listOf(ScimUser.Email("jon.basic@rogaland.no", primary = true)),
+                        name = ScimUser.Name(Users.JON_FIRST_NAME, Users.BASIC_LAST_NAME),
+                        emails = listOf(ScimUser.Email(Users.JON_ROGALAND, primary = true)),
                         roles =
                             listOf(
                                 ScimUser.Role("read", "read", "WindowsAzureActiveDirectoryRole", false),
                                 ScimUser.Role("write", "write", "WindowsAzureActiveDirectoryRole", false),
                             ),
-                        fintUserExtension = ScimUser.FintUserExtension("1234", "1234", "jon.basic@rogaland.no"),
+                        fintUserExtension = ScimUser.FintUserExtension("1234", "1234", Users.JON_ROGALAND),
                     ),
                 ),
         )
 
     @ParameterizedTest(name = "provision users to org ({0}) returns ok")
-    @ValueSource(strings = ["telemark", "rogaland"])
+    @ValueSource(strings = [Orgs.TELEMARK, Orgs.ROGALAND])
     fun `provision users to org returns ok`(
         orgAlias: String,
         env: KcEnvironment,

--- a/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/scim/ProvisionedTest.kt
+++ b/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/scim/ProvisionedTest.kt
@@ -6,9 +6,14 @@ import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import no.novari.test.common.config.KcConfig
-import no.novari.test.common.extensions.kc.KcEnvExtension
-import no.novari.test.common.utils.kc.KcAdminClient
-import no.novari.test.common.utils.kc.KcEnvironment
+import no.novari.test.common.environment.kc.KcEnvironment
+import no.novari.test.common.environment.kc.KcEnvironmentExtension
+import no.novari.test.common.fixture.TestStrings.Clients
+import no.novari.test.common.fixture.TestStrings.Idps
+import no.novari.test.common.fixture.TestStrings.Orgs
+import no.novari.test.common.fixture.TestStrings.Realms
+import no.novari.test.common.fixture.TestStrings.Users
+import no.novari.test.common.utils.KcAdminClient
 import no.novari.test.integration.utils.KcFlow.loginWithUser
 import no.novari.test.integration.utils.ScimFlow
 import no.novari.test.integration.utils.ScimFlow.ScimUser
@@ -22,13 +27,13 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@ExtendWith(KcEnvExtension::class)
+@ExtendWith(KcEnvironmentExtension::class)
 class ProvisionedTest {
-    private val realm = "external"
+    private val realm = Realms.EXTERNAL
 
     private val users =
         mapOf(
-            "telemark" to
+            Orgs.TELEMARK to
                 listOf(
                     ScimUser(
                         schemas =
@@ -37,16 +42,16 @@ class ProvisionedTest {
                                 "urn:ietf:params:scim:schemas:extension:fint:2.0:User",
                             ),
                         externalId = "11111111-1111-1111-1111-111111111111",
-                        userName = "alice.basic@telemark.no",
+                        userName = Users.ALICE_TELEMARK,
                         active = true,
-                        name = ScimUser.Name("Alice", "Basic"),
-                        emails = listOf(ScimUser.Email("alice.basic@telemark.no", primary = true)),
+                        name = ScimUser.Name(Users.ALICE_FIRST_NAME, Users.BASIC_LAST_NAME),
+                        emails = listOf(ScimUser.Email(Users.ALICE_TELEMARK, primary = true)),
                         roles =
                             listOf(
                                 ScimUser.Role("read", "read", "WindowsAzureActiveDirectoryRole", false),
                                 ScimUser.Role("write", "write", "WindowsAzureActiveDirectoryRole", false),
                             ),
-                        fintUserExtension = ScimUser.FintUserExtension("1234", "1234", "alice.basic@telemark.no"),
+                        fintUserExtension = ScimUser.FintUserExtension("1234", "1234", Users.ALICE_TELEMARK),
                     ),
                     ScimUser(
                         schemas =
@@ -54,19 +59,19 @@ class ProvisionedTest {
                                 "urn:ietf:params:scim:schemas:core:2.0:User",
                             ),
                         externalId = "22222222-2222-2222-2222-222222222222",
-                        userName = "jon.basic@telemark.no",
+                        userName = Users.JON_TELEMARK,
                         active = true,
-                        name = ScimUser.Name("Jon", "Basic"),
-                        emails = listOf(ScimUser.Email("jon.basic@telemark.no", primary = true)),
+                        name = ScimUser.Name(Users.JON_FIRST_NAME, Users.BASIC_LAST_NAME),
+                        emails = listOf(ScimUser.Email(Users.JON_TELEMARK, primary = true)),
                         roles =
                             listOf(
                                 ScimUser.Role("read", "read", "WindowsAzureActiveDirectoryRole", false),
                                 ScimUser.Role("write", "write", "WindowsAzureActiveDirectoryRole", false),
                             ),
-                        fintUserExtension = ScimUser.FintUserExtension("1234", "1234", "jon.basic@telemark.no"),
+                        fintUserExtension = ScimUser.FintUserExtension("1234", "1234", Users.JON_TELEMARK),
                     ),
                 ),
-            "rogaland" to
+            Orgs.ROGALAND to
                 listOf(
                     ScimUser(
                         schemas =
@@ -75,16 +80,16 @@ class ProvisionedTest {
                                 "urn:ietf:params:scim:schemas:extension:fint:2.0:User",
                             ),
                         externalId = "11111111-1111-1111-1111-111111111111",
-                        userName = "alice.basic@rogaland.no",
+                        userName = Users.ALICE_ROGALAND,
                         active = true,
-                        name = ScimUser.Name("Alice", "Basic"),
-                        emails = listOf(ScimUser.Email("alice.basic@rogaland.no", primary = true)),
+                        name = ScimUser.Name(Users.ALICE_FIRST_NAME, Users.BASIC_LAST_NAME),
+                        emails = listOf(ScimUser.Email(Users.ALICE_ROGALAND, primary = true)),
                         roles =
                             listOf(
                                 ScimUser.Role("read", "read", "WindowsAzureActiveDirectoryRole", false),
                                 ScimUser.Role("write", "write", "WindowsAzureActiveDirectoryRole", false),
                             ),
-                        fintUserExtension = ScimUser.FintUserExtension("1234", "1234", "alice.basic@rogaland.no"),
+                        fintUserExtension = ScimUser.FintUserExtension("1234", "1234", Users.ALICE_ROGALAND),
                     ),
                     ScimUser(
                         schemas =
@@ -92,16 +97,16 @@ class ProvisionedTest {
                                 "urn:ietf:params:scim:schemas:core:2.0:User",
                             ),
                         externalId = "22222222-2222-2222-2222-222222222222",
-                        userName = "jon.basic@rogaland.no",
+                        userName = Users.JON_ROGALAND,
                         active = true,
-                        name = ScimUser.Name("Jon", "Basic"),
-                        emails = listOf(ScimUser.Email("jon.basic@rogaland.no", primary = true)),
+                        name = ScimUser.Name(Users.JON_FIRST_NAME, Users.BASIC_LAST_NAME),
+                        emails = listOf(ScimUser.Email(Users.JON_ROGALAND, primary = true)),
                         roles =
                             listOf(
                                 ScimUser.Role("read", "read", "WindowsAzureActiveDirectoryRole", false),
                                 ScimUser.Role("write", "write", "WindowsAzureActiveDirectoryRole", false),
                             ),
-                        fintUserExtension = ScimUser.FintUserExtension("1234", "1234", "jon.basic@rogaland.no"),
+                        fintUserExtension = ScimUser.FintUserExtension("1234", "1234", Users.JON_ROGALAND),
                     ),
                 ),
         )
@@ -117,7 +122,7 @@ class ProvisionedTest {
             KcAdminClient.deleteAllUsers(realmRes)
         }
 
-        users["telemark"]?.forEach { user ->
+        users[Orgs.TELEMARK]?.forEach { user ->
             ScimFlow
                 .createUser(
                     "${env.keycloakServiceUrl()}/realms/external/scim/v2/${kcConfig.requireOrg("telemark").id}",
@@ -127,7 +132,7 @@ class ProvisionedTest {
                     assertEquals(201, resp.code)
                 }
         }
-        users["rogaland"]?.forEach { user ->
+        users[Orgs.ROGALAND]?.forEach { user ->
             ScimFlow
                 .createUser(
                     "${env.keycloakServiceUrl()}/realms/external/scim/v2/${kcConfig.requireOrg("rogaland").id}",
@@ -140,7 +145,7 @@ class ProvisionedTest {
     }
 
     @ParameterizedTest(name = "provisioned users in org ({0}) exists")
-    @ValueSource(strings = ["telemark", "rogaland"])
+    @ValueSource(strings = [Orgs.TELEMARK, Orgs.ROGALAND])
     fun `provisioned users in org exists`(
         orgAlias: String,
         env: KcEnvironment,
@@ -156,7 +161,7 @@ class ProvisionedTest {
     }
 
     @ParameterizedTest(name = "provisioned users in org ({0}) linked to correct idp")
-    @ValueSource(strings = ["telemark", "rogaland"])
+    @ValueSource(strings = [Orgs.TELEMARK, Orgs.ROGALAND])
     fun `provisioned users in org linked to correct idp`(
         orgAlias: String,
         env: KcEnvironment,
@@ -169,19 +174,19 @@ class ProvisionedTest {
                 assertNotNull(kcUser)
                 val identities = KcAdminClient.getFederatedIdentities(realmRes, kcUser.id)
                 assertNotNull(identities)
-                assertEquals("entra-$orgAlias", identities.first().identityProvider)
+                assertEquals(Idps.entra(orgAlias), identities.first().identityProvider)
             }
         }
     }
 
     @ParameterizedTest(name = "provisioned users in org ({0}) can login")
-    @ValueSource(strings = ["telemark", "rogaland"])
+    @ValueSource(strings = [Orgs.TELEMARK, Orgs.ROGALAND])
     fun `provisioned users in org can login`(
         orgAlias: String,
         env: KcEnvironment,
     ) {
-        val clientId = "flais-keycloak-demo"
-        val idpAlias = "entra-$orgAlias"
+        val clientId = Clients.FLAIS_KEYCLOAK_DEMO
+        val idpAlias = Idps.entra(orgAlias)
 
         users[orgAlias]?.forEach { user ->
             loginWithUser(
@@ -190,8 +195,8 @@ class ProvisionedTest {
                 orgAlias,
                 idpAlias,
                 user.userName,
-                "password",
-                hasIdpSelector = (orgAlias == "telemark"),
+                Users.PASSWORD,
+                hasIdpSelector = (orgAlias == Orgs.TELEMARK),
             ).use { resp ->
                 assertEquals(200, resp.code)
 
@@ -201,7 +206,7 @@ class ProvisionedTest {
     }
 
     @ParameterizedTest(name = "updating provisioned users in org ({0}) updates users with new info")
-    @ValueSource(strings = ["telemark", "rogaland"])
+    @ValueSource(strings = [Orgs.TELEMARK, Orgs.ROGALAND])
     fun `updating provisioned users in org updates users with new info`(
         orgAlias: String,
         env: KcEnvironment,
@@ -239,7 +244,7 @@ class ProvisionedTest {
     }
 
     @ParameterizedTest(name = "patching provisioned users in org ({0}) patches users with new info")
-    @ValueSource(strings = ["telemark", "rogaland"])
+    @ValueSource(strings = [Orgs.TELEMARK, Orgs.ROGALAND])
     fun `patching provisioned users in org patches users with new info`(
         orgAlias: String,
         env: KcEnvironment,
@@ -304,7 +309,7 @@ class ProvisionedTest {
     }
 
     @ParameterizedTest(name = "patching provisioned users in org ({0}) using full urn definition patches users with new info")
-    @ValueSource(strings = ["telemark", "rogaland"])
+    @ValueSource(strings = [Orgs.TELEMARK, Orgs.ROGALAND])
     fun `patching provisioned users in org using full urn definition patches users with new info`(
         orgAlias: String,
         env: KcEnvironment,
@@ -422,7 +427,6 @@ class ProvisionedTest {
                         assertEquals(
                             value.jsonPrimitive.content,
                             kcUser.attributes[attributeName]?.first(),
-                            "Mismatch for attribute $attributeName",
                         )
                     }
             }
@@ -451,14 +455,14 @@ class ProvisionedTest {
                 kcUser = KcAdminClient.findUserByUsername(realmRes, user.userName)
                 assertNotNull(kcUser)
 
-                assertEquals("Jeanette", kcUser.firstName, "Mismatch for givenName/firstName")
-                assertEquals("Bergersen", kcUser.lastName, "Mismatch for familyName/lastName")
+                assertEquals("Jeanette", kcUser.firstName)
+                assertEquals("Bergersen", kcUser.lastName)
             }
         }
     }
 
     @ParameterizedTest(name = "deprovision users in org ({0}) removed")
-    @ValueSource(strings = ["telemark", "rogaland"])
+    @ValueSource(strings = [Orgs.TELEMARK, Orgs.ROGALAND])
     fun `deprovision users in org removed`(
         orgAlias: String,
         env: KcEnvironment,

--- a/keycloak/src/test/integration/kotlin/no/novari/test/integration/utils/KcFlow.kt
+++ b/keycloak/src/test/integration/kotlin/no/novari/test/integration/utils/KcFlow.kt
@@ -1,7 +1,7 @@
 package no.novari.test.integration.utils
 
-import no.novari.test.common.utils.kc.KcEnvironment
-import no.novari.test.common.utils.kc.KcUrl
+import no.novari.test.common.environment.kc.KcEnvironment
+import no.novari.test.common.utils.KcUrl
 import okhttp3.FormBody
 import okhttp3.HttpUrl
 import okhttp3.MediaType.Companion.toMediaType

--- a/keycloak/src/test/integration/kotlin/no/novari/test/integration/utils/KcToken.kt
+++ b/keycloak/src/test/integration/kotlin/no/novari/test/integration/utils/KcToken.kt
@@ -1,6 +1,6 @@
 package no.novari.test.integration.utils
 
-import no.novari.test.common.utils.kc.KcEnvironment
+import no.novari.test.common.environment.kc.KcEnvironment
 import okhttp3.FormBody
 import okhttp3.OkHttpClient
 import okhttp3.Request

--- a/keycloak/src/test/system/kotlin/no/novari/test/system/e2e/clients/BrowserClientLoginTest.kt
+++ b/keycloak/src/test/system/kotlin/no/novari/test/system/e2e/clients/BrowserClientLoginTest.kt
@@ -2,8 +2,8 @@ package no.novari.test.system.e2e.clients
 
 import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
 import no.novari.test.common.annotations.PwTest
-import no.novari.test.common.utils.kc.KcEnvironment
-import no.novari.test.common.utils.pw.PwEnvironment
+import no.novari.test.common.environment.kc.KcEnvironment
+import no.novari.test.common.environment.pw.PwEnvironment
 import no.novari.test.system.utils.PwFlow
 import org.junit.jupiter.api.TestTemplate
 

--- a/keycloak/src/test/system/kotlin/no/novari/test/system/e2e/theme/FlaisLoginThemeTest.kt
+++ b/keycloak/src/test/system/kotlin/no/novari/test/system/e2e/theme/FlaisLoginThemeTest.kt
@@ -3,8 +3,12 @@ package no.novari.test.system.e2e.theme
 import com.microsoft.playwright.Page
 import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
 import no.novari.test.common.annotations.PwTest
-import no.novari.test.common.utils.kc.KcEnvironment
-import no.novari.test.common.utils.pw.PwEnvironment
+import no.novari.test.common.environment.kc.KcEnvironment
+import no.novari.test.common.environment.pw.PwEnvironment
+import no.novari.test.common.fixture.TestStrings.Clients
+import no.novari.test.common.fixture.TestStrings.Idps
+import no.novari.test.common.fixture.TestStrings.Orgs
+import no.novari.test.common.fixture.TestStrings.Users
 import no.novari.test.system.utils.PwAutoLogin
 import no.novari.test.system.utils.PwFlow
 import org.junit.jupiter.api.TestTemplate
@@ -19,11 +23,11 @@ class FlaisLoginThemeTest {
     ) {
         val page = session.page
 
-        PwFlow.navigateToLogin(env, page, clientId = "flais-keycloak-demo")
-        PwFlow.continueFromOrgSelector(page, "Rogaland")
+        PwFlow.navigateToLogin(env, page, clientId = Clients.FLAIS_KEYCLOAK_DEMO)
+        PwFlow.continueFromOrgSelector(page, Orgs.ROGALAND_DISPLAY_NAME)
         PwFlow.submit(page)
 
-        PwAutoLogin.login(page, "alice.basic@rogaland.no", "password")
+        PwAutoLogin.login(page, Users.ALICE_ROGALAND, Users.PASSWORD)
 
         assertCallback(env, page)
     }
@@ -35,12 +39,12 @@ class FlaisLoginThemeTest {
     ) {
         val page = session.page
 
-        PwFlow.navigateToLogin(env, page, clientId = "flais-keycloak-demo")
-        PwFlow.continueFromOrgSelector(page, "Telemark")
+        PwFlow.navigateToLogin(env, page, clientId = Clients.FLAIS_KEYCLOAK_DEMO)
+        PwFlow.continueFromOrgSelector(page, Orgs.TELEMARK_DISPLAY_NAME)
         PwFlow.submit(page)
 
-        PwFlow.continueFromIdpSelector(page, "entra-telemark")
-        PwAutoLogin.login(page, "alice.basic@telemark.no", "password")
+        PwFlow.continueFromIdpSelector(page, Idps.ENTRA_TELEMARK)
+        PwAutoLogin.login(page, Users.ALICE_TELEMARK, Users.PASSWORD)
 
         assertCallback(env, page)
     }
@@ -52,7 +56,7 @@ class FlaisLoginThemeTest {
     ) {
         val page = session.page
 
-        PwFlow.navigateToLogin(env, page, clientId = "flais-keycloak-demo")
+        PwFlow.navigateToLogin(env, page, clientId = Clients.FLAIS_KEYCLOAK_DEMO)
         PwFlow.submit(page)
 
         assertThat(page).hasURL(

--- a/keycloak/src/test/system/kotlin/no/novari/test/system/e2e/theme/FlaisLoginThemeTest.kt
+++ b/keycloak/src/test/system/kotlin/no/novari/test/system/e2e/theme/FlaisLoginThemeTest.kt
@@ -8,6 +8,7 @@ import no.novari.test.common.environment.pw.PwEnvironment
 import no.novari.test.common.fixture.TestStrings.Clients
 import no.novari.test.common.fixture.TestStrings.Idps
 import no.novari.test.common.fixture.TestStrings.Orgs
+import no.novari.test.common.fixture.TestStrings.Uris
 import no.novari.test.common.fixture.TestStrings.Users
 import no.novari.test.system.utils.PwAutoLogin
 import no.novari.test.system.utils.PwFlow
@@ -69,7 +70,7 @@ class FlaisLoginThemeTest {
         page: Page,
     ) {
         assertThat(page).hasURL(
-            Pattern.compile("${env.flaisKeycloakDemoUrl()}/callback"),
+            Pattern.compile(Uris.redirectCallback(env.flaisKeycloakDemoUrl())),
         )
     }
 }

--- a/keycloak/src/test/system/kotlin/no/novari/test/system/utils/PwFlow.kt
+++ b/keycloak/src/test/system/kotlin/no/novari/test/system/utils/PwFlow.kt
@@ -3,8 +3,8 @@ package no.novari.test.system.utils
 import com.microsoft.playwright.Locator
 import com.microsoft.playwright.Page
 import com.microsoft.playwright.options.AriaRole
-import no.novari.test.common.utils.kc.KcEnvironment
-import no.novari.test.common.utils.kc.KcUrl
+import no.novari.test.common.environment.kc.KcEnvironment
+import no.novari.test.common.utils.KcUrl
 
 /**
  * Utility functions to simplify Playwright flows in system tests.


### PR DESCRIPTION
Refactors the Keycloak test support structure to make environment-related code clearer and reduce duplication across integration and system tests.

## Changes

- Renames and moves test environment classes from `extensions`, `utils.kc`, and `utils.pw` into a shared `environment` package.
- Renames JUnit extensions for clarity:
  - `KcEnvExtension` → `KcEnvironmentExtension`
  - `PwEnvExtension` → `PwEnvironmentExtension`
- Introduces `TestStrings` as a central fixture source for common test values such as clients, organizations, identity providers, realms, scopes, users, and page IDs.
- Updates integration and Playwright tests to use shared fixture constants instead of repeated string literals.
- Moves generic Keycloak utilities such as `KcAdminClient` and `KcUrl` into `no.novari.test.common.utils`.
- Applies minor cleanup in tests and environment classes while preserving existing test behavior.