### PR TITLE
FLA-1666: Fix Keycloak provider JAR copy path in Docker build

### DIFF
--- a/keycloak/Dockerfile
+++ b/keycloak/Dockerfile
@@ -32,6 +32,7 @@ RUN --mount=type=cache,target=/home/gradle/.gradle \
     ./gradlew --no-daemon --configuration-cache \
         :libs:flais-provider:build \
         :libs:flais-scim-server:build \
+    && mkdir -p /flais-keycloak-jars \
     && cp libs/flais-provider/build/libs/*.jar /flais-keycloak-jars/ \
     && cp libs/flais-scim-server/build/libs/*.jar /flais-keycloak-jars/
 

--- a/keycloak/Dockerfile
+++ b/keycloak/Dockerfile
@@ -33,8 +33,8 @@ RUN --mount=type=cache,target=/home/gradle/.gradle \
         :libs:flais-provider:build \
         :libs:flais-scim-server:build \
     && mkdir -p /flais-keycloak-jars \
-    && cp libs/flais-provider/build/libs/*.jar / \
-    && cp libs/flais-scim-server/build/libs/*.jar /
+    && cp libs/flais-provider/build/libs/*.jar /flais-keycloak-jars/ \
+    && cp libs/flais-scim-server/build/libs/*.jar /flais-keycloak-jars/
 
 # ---------------------------
 # Stage: FLAIS theme builder
@@ -64,7 +64,7 @@ ENV KC_DB=postgres
 ENV KC_HEALTH_ENABLED=true
 ENV KC_METRICS_ENABLED=true
 
-COPY --from=flais-keycloak-builder /*.jar /opt/keycloak/providers/
+COPY --from=flais-keycloak-builder /flais-keycloak-jars/*.jar /opt/keycloak/providers/
 
 COPY --from=flais-theme-builder /flais-theme/dist_keycloak/flais-theme.jar /opt/keycloak/providers/
 

--- a/keycloak/Dockerfile
+++ b/keycloak/Dockerfile
@@ -32,7 +32,6 @@ RUN --mount=type=cache,target=/home/gradle/.gradle \
     ./gradlew --no-daemon --configuration-cache \
         :libs:flais-provider:build \
         :libs:flais-scim-server:build \
-    && mkdir -p /flais-keycloak-jars \
     && cp libs/flais-provider/build/libs/*.jar /flais-keycloak-jars/ \
     && cp libs/flais-scim-server/build/libs/*.jar /flais-keycloak-jars/
 


### PR DESCRIPTION
Updates the Keycloak Dockerfile so FLAIS provider and SCIM server JARs are copied into a dedicated /flais-keycloak-jars/ directory during the builder stage, then copied from that directory into /opt/keycloak/providers/ in the final image.

This avoids relying on a broad /*.jar copy from the filesystem root and keeps build artifacts isolated and explicit.