### PR TITLE
FLA-1675: Move name from complex attribute to flat on extension:fint:2.0:User

### DIFF
--- a/docs/config/fint/entra-id/enterprise-application.md
+++ b/docs/config/fint/entra-id/enterprise-application.md
@@ -69,8 +69,8 @@ This assignment controls:
 | `userName`                                                               | String  |     | Yes      |             |
 | `externalId`                                                             | String  |     | Yes      |             |
 | `roles`                                                                  | String  |     |          | Yes         |
-| `urn:ietf:params:scim:schemas:core:2.0:User:name.givenName`              | String  |     |          |             |
-| `urn:ietf:params:scim:schemas:core:2.0:User:name.familyName`             | String  |     |          |             |
+| `urn:ietf:params:scim:schemas:extension:fint:2.0:User:givenName`         | String  |     |          |             |
+| `urn:ietf:params:scim:schemas:extension:fint:2.0:User:familyName`        | String  |     |          |             |
 | `urn:ietf:params:scim:schemas:extension:fint:2.0:User:userPrincipalName` | String  |     |          |             |
 | `urn:ietf:params:scim:schemas:extension:fint:2.0:User:employeeId`        | String  |     |          |             |
 | `urn:ietf:params:scim:schemas:extension:fint:2.0:User:studentNumber`     | String  |     |          |             |
@@ -86,8 +86,8 @@ This assignment controls:
 | `emails[type eq "work"].value`                                           | `mail`                                                        |
 | `externalId`                                                             | `objectId`                                                    |
 | `roles`                                                                  | `AssertiveAppRoleAssignmentsComplex([appRoleAssignments])`    |
-| `urn:ietf:params:scim:schemas:core:2.0:User:name.givenName`              | `givenName`                                                   |
-| `urn:ietf:params:scim:schemas:core:2.0:User:name.familyName`             | `surname`                                                     |
+| `urn:ietf:params:scim:schemas:extension:fint:2.0:User:givenName`         | `givenName`                                                   |
+| `urn:ietf:params:scim:schemas:extension:fint:2.0:User:familyName`        | `surname`                                                     |
 | `urn:ietf:params:scim:schemas:extension:fint:2.0:User:userPrincipalName` | `userPrincipalName`                                           |
 | `urn:ietf:params:scim:schemas:extension:fint:2.0:User:employeeId`        | `extensionAttribute10`                                        |
 | `urn:ietf:params:scim:schemas:extension:fint:2.0:User:studentNumber`     | `extensionAttribute9`                                         |
@@ -99,7 +99,7 @@ This assignment controls:
 - Does not support the `remove` operation in `PATCH` when clearing an attribute value. The field is silently skipped.
     - Source: https://learn.microsoft.com/en-us/answers/questions/223936/sending-an-empty-value-with-user-provisioning-%28sci?page=1&orderby=Helpful&comment=answer-224218&translated=false
 - The feature flag `aadOptscim062020` does not follow SCIM RFC 7644.
-    - This is handled on our side but requires full definitions for core complex attributes (e.g., `name.givenName`) in the Attribute mapping. Example: `urn:ietf:params:scim:schemas:core:2.0:User:name.givenName`
+    - We try to avoide complex attributes where possible, Microsoft also points out they have limited support for this in their docs. (e.g., `name.givenName`) in the Attribute mapping. Example: `urn:ietf:params:scim:schemas:extension:fint:2.0:User:givenName`
     - RFC: https://datatracker.ietf.org/doc/html/rfc7644#section-3.5.2
     - Source: https://learn.microsoft.com/en-us/entra/identity/app-provisioning/application-provisioning-config-problem-scim-compatibility
 - POST/PATCH payload is different for roles, so you end up having to wait 2 cycles for the roles to be provisioned correctly.

--- a/docs/config/fint/entra-id/enterprise-application.md
+++ b/docs/config/fint/entra-id/enterprise-application.md
@@ -102,6 +102,7 @@ This assignment controls:
     - We try to avoide complex attributes where possible, Microsoft also points out they have limited support for this in their docs. (e.g., `name.givenName`) in the Attribute mapping. Example: `urn:ietf:params:scim:schemas:extension:fint:2.0:User:givenName`
     - RFC: https://datatracker.ietf.org/doc/html/rfc7644#section-3.5.2
     - Source: https://learn.microsoft.com/en-us/entra/identity/app-provisioning/application-provisioning-config-problem-scim-compatibility
+    - Source: https://learn.microsoft.com/en-us/entra/identity/app-provisioning/customize-application-attributes?source=recommendations#provisioning-a-custom-extension-attribute-to-a-scim-compliant-application
 - POST/PATCH payload is different for roles, so you end up having to wait 2 cycles for the roles to be provisioned correctly.
     - Solved by using the feature flag `aadOptscim062020`
     - Source: https://learn.microsoft.com/nb-no/entra/identity/app-provisioning/customize-application-attributes#provisioning-a-role-to-a-scim-app

--- a/keycloak/config/scimverify/entra-rogaland.yaml
+++ b/keycloak/config/scimverify/entra-rogaland.yaml
@@ -19,13 +19,15 @@ users:
                   "externalId": "11111111-1111-1111-1111-111111111111",
                   "userName": "alice.basic@rogaland.no",
                   "active": true,
-                  "givenName": "Alice",
-                  "familyName": "Basic",
                   "emails":
                     [ { "value": "alice.basic@rogaland.no", "primary": true } ],
                   "roles": [ { "value": "read","display": "read","type": "WindowsAzureActiveDirectoryRole","primary": false } ],
                   "urn:ietf:params:scim:schemas:extension:fint:2.0:User": {
-                      "employeeId": "1234", "studentNumber": "1234", "userPrincipalName": "alice.basic@rogaland.no"
+                      "givenName": "Alice",
+                      "familyName": "Basic",
+                      "employeeId": "1234",
+                      "studentNumber": "1234",
+                      "userPrincipalName": "alice.basic@rogaland.no"
                   }
               }
             response:
@@ -155,12 +157,12 @@ users:
                   "externalId": "11111111-1111-1111-1111-111111111111",
                   "userName": "alice.basic@rogaland.no",
                   "active": true,
-                  "givenName": "Alice2",
-                  "familyName": "Basic2",
                   "emails":
                     [ { "value": "alice.basic@rogaland.no", "primary": true } ],
                   "roles": [ { "value": "read","display": "read","type": "WindowsAzureActiveDirectoryRole","primary": false }, { "value": "write","display": "write","type": "WindowsAzureActiveDirectoryRole","primary": false } ],
                   "urn:ietf:params:scim:schemas:extension:fint:2.0:User": {
+                      "givenName": "Alice2",
+                      "familyName": "Basic2",
                       "employeeId": "12_34",
                       "studentNumber": "12_34",
                       "userPrincipalName": "alice.basic@rogaland.no"
@@ -198,16 +200,6 @@ users:
                                       {
                                           "type": "string",
                                           "const": "alice.basic@rogaland.no",
-                                      },
-                                    "givenName":
-                                      {
-                                          "type": "string",
-                                          "const": "Alice2",
-                                      },
-                                    "familyName":
-                                      {
-                                          "type": "string",
-                                          "const": "Basic2",
                                       },
                                     "emails":
                                       {
@@ -294,6 +286,16 @@ users:
                         "urn:ietf:params:scim:schemas:extension:fint:2.0:User": {
                             "type": "object",
                             "properties": {
+                                "givenName":
+                                  {
+                                      "type": "string",
+                                      "const": "Alice2",
+                                  },
+                                "familyName":
+                                  {
+                                      "type": "string",
+                                      "const": "Basic2",
+                                  },
                                 "employeeId": {
                                     "type": "string",
                                     "const": "12_34"
@@ -322,58 +324,72 @@ users:
               }
 
     patch_tests:
-        -   id: AUTO
-            request:
-              {
-                  "schemas": [ "urn:ietf:params:scim:api:messages:2.0:PatchOp" ],
-                  "Operations":
-                    [
+        - id: AUTO
+          request:
+            {
+                "schemas": [ "urn:ietf:params:scim:api:messages:2.0:PatchOp" ],
+                "Operations":
+                  [
+                      {
+                          "op": "replace",
+                          "path": "emails[primary eq true].value",
+                          "value": "alice.basic.new@rogaland.no",
+                      },
+                  ],
+            }
+          response:
+            {
+                "type": "object",
+                "properties":
+                  {
+                      "schemas":
                         {
-                            "op": "replace",
-                            "path": "familyName",
-                            "value": "alice2",
+                            "type": "array",
+                            "items": { "type": "string" },
+                            "contains":
+                              {
+                                  "const": "urn:ietf:params:scim:schemas:core:2.0:User",
+                              },
                         },
-                    ],
-              }
-            response:
-              {
-                  "type": "object",
-                  "properties":
-                    {
-                        "schemas":
-                          {
-                              "type": "array",
-                              "items": { "type": "string" },
-                              "contains":
-                                {
-                                    "const": "urn:ietf:params:scim:schemas:core:2.0:User",
-                                },
-                          },
-                        "id": { "type": "string" },
-                        "meta": { "type": "object" },
-                        "urn:ietf:params:scim:schemas:core:2.0:User":
-                          {
-                              "type": "object",
-                              "properties":
-                                {
-                                    "familyName":
-                                      {
-                                          "type": "string",
-                                          "const": "alice2",
-                                      },
-                                },
-                              "required": [ "familyName" ],
-                              "additionalProperties": true,
-                          },
-                    },
-                  "required":
-                    [
-                        "schemas",
-                        "id",
-                        "urn:ietf:params:scim:schemas:core:2.0:User",
-                    ],
-                  "additionalProperties": true,
-              }
+                      "id": { "type": "string" },
+                      "meta": { "type": "object" },
+                      "urn:ietf:params:scim:schemas:core:2.0:User":
+                        {
+                            "type": "object",
+                            "properties":
+                              {
+                                  "emails":
+                                    {
+                                        "type": "array",
+                                        "contains":
+                                          {
+                                              "type": "object",
+                                              "properties":
+                                                {
+                                                    "primary": { "const": true },
+                                                    "value":
+                                                      {
+                                                          "type": "string",
+                                                          "const": "alice.basic.new@rogaland.no",
+                                                      },
+                                                },
+                                              "required": [ "primary", "value" ],
+                                              "additionalProperties": true,
+                                          },
+                                    },
+                              },
+                            "required": [ "emails" ],
+                            "additionalProperties": true,
+                        },
+                  },
+                "required":
+                  [
+                      "schemas",
+                      "id",
+                      "urn:ietf:params:scim:schemas:core:2.0:User",
+                  ],
+                "additionalProperties": true,
+            }
         -   id: AUTO
             request:
               {

--- a/keycloak/config/scimverify/entra-rogaland.yaml
+++ b/keycloak/config/scimverify/entra-rogaland.yaml
@@ -330,7 +330,7 @@ users:
                     [
                         {
                             "op": "replace",
-                            "path": "name.familyName",
+                            "path": "familyName",
                             "value": "alice2",
                         },
                     ],
@@ -356,20 +356,13 @@ users:
                               "type": "object",
                               "properties":
                                 {
-                                    "name":
+                                    "familyName":
                                       {
-                                          "type": "object",
-                                          "properties":
-                                            {
-                                                "familyName":
-                                                  {
-                                                      "type": "string",
-                                                      "const": "alice2",
-                                                  },
-                                            },
+                                          "type": "string",
+                                          "const": "alice2",
                                       },
                                 },
-                              "required": [ "name" ],
+                              "required": [ "familyName" ],
                               "additionalProperties": true,
                           },
                     },

--- a/keycloak/config/scimverify/entra-rogaland.yaml
+++ b/keycloak/config/scimverify/entra-rogaland.yaml
@@ -19,7 +19,8 @@ users:
                   "externalId": "11111111-1111-1111-1111-111111111111",
                   "userName": "alice.basic@rogaland.no",
                   "active": true,
-                  "name": { "givenName": "Alice", "familyName": "Basic" },
+                  "givenName": "Alice",
+                  "familyName": "Basic",
                   "emails":
                     [ { "value": "alice.basic@rogaland.no", "primary": true } ],
                   "roles": [ { "value": "read","display": "read","type": "WindowsAzureActiveDirectoryRole","primary": false } ],
@@ -154,7 +155,8 @@ users:
                   "externalId": "11111111-1111-1111-1111-111111111111",
                   "userName": "alice.basic@rogaland.no",
                   "active": true,
-                  "name": { "givenName": "Alice2", "familyName": "Basic2" },
+                  "givenName": "Alice2",
+                  "familyName": "Basic2",
                   "emails":
                     [ { "value": "alice.basic@rogaland.no", "primary": true } ],
                   "roles": [ { "value": "read","display": "read","type": "WindowsAzureActiveDirectoryRole","primary": false }, { "value": "write","display": "write","type": "WindowsAzureActiveDirectoryRole","primary": false } ],
@@ -197,22 +199,15 @@ users:
                                           "type": "string",
                                           "const": "alice.basic@rogaland.no",
                                       },
-                                    "name":
+                                    "givenName":
                                       {
-                                          "type": "object",
-                                          "properties":
-                                            {
-                                                "givenName":
-                                                  {
-                                                      "type": "string",
-                                                      "const": "Alice2",
-                                                  },
-                                                "familyName":
-                                                  {
-                                                      "type": "string",
-                                                      "const": "Basic2",
-                                                  },
-                                            },
+                                          "type": "string",
+                                          "const": "Alice2",
+                                      },
+                                    "familyName":
+                                      {
+                                          "type": "string",
+                                          "const": "Basic2",
                                       },
                                     "emails":
                                       {

--- a/keycloak/config/scimverify/entra-telemark.yaml
+++ b/keycloak/config/scimverify/entra-telemark.yaml
@@ -19,13 +19,16 @@ users:
                   "externalId": "11111111-1111-1111-1111-111111111111",
                   "userName": "alice.basic@telemark.no",
                   "active": true,
-                  "givenName": "Alice",
-                  "familyName": "Basic",
+
                   "emails":
                     [ { "value": "alice.basic@telemark.no", "primary": true } ],
                   "roles": [ { "value": "read","display": "read","type": "WindowsAzureActiveDirectoryRole","primary": false } ],
                   "urn:ietf:params:scim:schemas:extension:fint:2.0:User": {
-                      "employeeId": "1234", "studentNumber": "1234", "userPrincipalName": "alice.basic@telemark.no"
+                      "givenName": "Alice",
+                      "familyName": "Basic",
+                      "employeeId": "1234",
+                      "studentNumber": "1234",
+                      "userPrincipalName": "alice.basic@telemark.no"
                   }
               }
             response:
@@ -156,12 +159,12 @@ users:
                   "externalId": "11111111-1111-1111-1111-111111111111",
                   "userName": "alice.basic@telemark.no",
                   "active": true,
-                  givenName: "Alice2",
-                  familyName: "Basic2",
                   "emails":
                     [ { "value": "alice.basic@telemark.no", "primary": true } ],
                   "roles": [ { "value": "read","display": "read","type": "WindowsAzureActiveDirectoryRole","primary": false }, { "value": "write","display": "write","type": "WindowsAzureActiveDirectoryRole","primary": false } ],
                   "urn:ietf:params:scim:schemas:extension:fint:2.0:User": {
+                      givenName: "Alice2",
+                      familyName: "Basic2",
                       "employeeId": "12_34",
                       "studentNumber": "12_34",
                       "userPrincipalName": "alice.basic@telemark.no"
@@ -199,16 +202,6 @@ users:
                                       {
                                           "type": "string",
                                           "const": "alice.basic@telemark.no",
-                                      },
-                                    "givenName":
-                                      {
-                                          "type": "string",
-                                          "const": "Alice2",
-                                      },
-                                    "familyName":
-                                      {
-                                          "type": "string",
-                                          "const": "Basic2",
                                       },
                                     "emails":
                                       {
@@ -295,6 +288,16 @@ users:
                         "urn:ietf:params:scim:schemas:extension:fint:2.0:User": {
                             "type": "object",
                             "properties": {
+                                "givenName":
+                                  {
+                                      "type": "string",
+                                      "const": "Alice2",
+                                  },
+                                "familyName":
+                                  {
+                                      "type": "string",
+                                      "const": "Basic2",
+                                  },
                                 "employeeId": {
                                     "type": "string",
                                     "const": "12_34"
@@ -323,58 +326,72 @@ users:
               }
 
     patch_tests:
-        -   id: AUTO
-            request:
-              {
-                  "schemas": [ "urn:ietf:params:scim:api:messages:2.0:PatchOp" ],
-                  "Operations":
-                    [
+        - id: AUTO
+          request:
+            {
+                "schemas": [ "urn:ietf:params:scim:api:messages:2.0:PatchOp" ],
+                "Operations":
+                  [
+                      {
+                          "op": "replace",
+                          "path": "emails[primary eq true].value",
+                          "value": "alice.basic.new@telemark.no",
+                      },
+                  ],
+            }
+          response:
+            {
+                "type": "object",
+                "properties":
+                  {
+                      "schemas":
                         {
-                            "op": "replace",
-                            "path": "familyName",
-                            "value": "alice2",
+                            "type": "array",
+                            "items": { "type": "string" },
+                            "contains":
+                              {
+                                  "const": "urn:ietf:params:scim:schemas:core:2.0:User",
+                              },
                         },
-                    ],
-              }
-            response:
-              {
-                  "type": "object",
-                  "properties":
-                    {
-                        "schemas":
-                          {
-                              "type": "array",
-                              "items": { "type": "string" },
-                              "contains":
-                                {
-                                    "const": "urn:ietf:params:scim:schemas:core:2.0:User",
-                                },
-                          },
-                        "id": { "type": "string" },
-                        "meta": { "type": "object" },
-                        "urn:ietf:params:scim:schemas:core:2.0:User":
-                          {
-                              "type": "object",
-                              "properties":
-                                {
-                                    "familyName":
-                                      {
-                                          "type": "string",
-                                          "const": "alice2",
-                                      },
-                                },
-                              "required": [ "familyName" ],
-                              "additionalProperties": true,
-                          },
-                    },
-                  "required":
-                    [
-                        "schemas",
-                        "id",
-                        "urn:ietf:params:scim:schemas:core:2.0:User",
-                    ],
-                  "additionalProperties": true,
-              }
+                      "id": { "type": "string" },
+                      "meta": { "type": "object" },
+                      "urn:ietf:params:scim:schemas:core:2.0:User":
+                        {
+                            "type": "object",
+                            "properties":
+                              {
+                                  "emails":
+                                    {
+                                        "type": "array",
+                                        "contains":
+                                          {
+                                              "type": "object",
+                                              "properties":
+                                                {
+                                                    "primary": { "const": true },
+                                                    "value":
+                                                      {
+                                                          "type": "string",
+                                                          "const": "alice.basic.new@telemark.no",
+                                                      },
+                                                },
+                                              "required": [ "primary", "value" ],
+                                              "additionalProperties": true,
+                                          },
+                                    },
+                              },
+                            "required": [ "emails" ],
+                            "additionalProperties": true,
+                        },
+                  },
+                "required":
+                  [
+                      "schemas",
+                      "id",
+                      "urn:ietf:params:scim:schemas:core:2.0:User",
+                  ],
+                "additionalProperties": true,
+            }
         -   id: AUTO
             request:
               {

--- a/keycloak/config/scimverify/entra-telemark.yaml
+++ b/keycloak/config/scimverify/entra-telemark.yaml
@@ -19,7 +19,8 @@ users:
                   "externalId": "11111111-1111-1111-1111-111111111111",
                   "userName": "alice.basic@telemark.no",
                   "active": true,
-                  "name": { "givenName": "Alice", "familyName": "Basic" },
+                  "givenName": "Alice",
+                  "familyName": "Basic",
                   "emails":
                     [ { "value": "alice.basic@telemark.no", "primary": true } ],
                   "roles": [ { "value": "read","display": "read","type": "WindowsAzureActiveDirectoryRole","primary": false } ],
@@ -155,7 +156,8 @@ users:
                   "externalId": "11111111-1111-1111-1111-111111111111",
                   "userName": "alice.basic@telemark.no",
                   "active": true,
-                  "name": { "givenName": "Alice2", "familyName": "Basic2" },
+                  givenName: "Alice2",
+                  familyName: "Basic2",
                   "emails":
                     [ { "value": "alice.basic@telemark.no", "primary": true } ],
                   "roles": [ { "value": "read","display": "read","type": "WindowsAzureActiveDirectoryRole","primary": false }, { "value": "write","display": "write","type": "WindowsAzureActiveDirectoryRole","primary": false } ],
@@ -198,22 +200,15 @@ users:
                                           "type": "string",
                                           "const": "alice.basic@telemark.no",
                                       },
-                                    "name":
+                                    "givenName":
                                       {
-                                          "type": "object",
-                                          "properties":
-                                            {
-                                                "givenName":
-                                                  {
-                                                      "type": "string",
-                                                      "const": "Alice2",
-                                                  },
-                                                "familyName":
-                                                  {
-                                                      "type": "string",
-                                                      "const": "Basic2",
-                                                  },
-                                            },
+                                          "type": "string",
+                                          "const": "Alice2",
+                                      },
+                                    "familyName":
+                                      {
+                                          "type": "string",
+                                          "const": "Basic2",
                                       },
                                     "emails":
                                       {

--- a/keycloak/config/scimverify/entra-telemark.yaml
+++ b/keycloak/config/scimverify/entra-telemark.yaml
@@ -331,7 +331,7 @@ users:
                     [
                         {
                             "op": "replace",
-                            "path": "name.familyName",
+                            "path": "familyName",
                             "value": "alice2",
                         },
                     ],
@@ -357,20 +357,13 @@ users:
                               "type": "object",
                               "properties":
                                 {
-                                    "name":
+                                    "familyName":
                                       {
-                                          "type": "object",
-                                          "properties":
-                                            {
-                                                "familyName":
-                                                  {
-                                                      "type": "string",
-                                                      "const": "alice2",
-                                                  },
-                                            },
+                                          "type": "string",
+                                          "const": "alice2",
                                       },
                                 },
-                              "required": [ "name" ],
+                              "required": [ "familyName" ],
                               "additionalProperties": true,
                           },
                     },

--- a/keycloak/libs/flais-scim-server/src/main/kotlin/no/novari/keycloak/scim/endpoints/ScimUserEndpoint.kt
+++ b/keycloak/libs/flais-scim-server/src/main/kotlin/no/novari/keycloak/scim/endpoints/ScimUserEndpoint.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode
 import com.unboundid.scim2.common.annotations.Attribute
 import com.unboundid.scim2.common.messages.PatchRequest
 import com.unboundid.scim2.common.types.Email
-import com.unboundid.scim2.common.types.EnterpriseUserExtension
 import com.unboundid.scim2.common.types.Role
 import com.unboundid.scim2.common.utils.ApiConstants
 import com.unboundid.scim2.common.utils.JsonUtils
@@ -45,7 +44,7 @@ import kotlin.streams.asSequence
     description = "User Account",
     name = "User",
     schema = UserResource::class,
-    optionalSchemaExtensions = [EnterpriseUserExtension::class, FintUserExtension::class],
+    optionalSchemaExtensions = [FintUserExtension::class],
 )
 @ResourcePath("Users")
 class ScimUserEndpoint(
@@ -305,6 +304,18 @@ class ScimUserEndpoint(
             user.isEmailVerified = false
         }
 
+        scimUser.givenName?.let {
+            user.firstName = it
+        } ?: run {
+            user.firstName = null
+        }
+
+        scimUser.familyName?.let {
+            user.lastName = it
+        } ?: {
+            user.lastName = null
+        }
+
         scimUser.roles?.let {
             user.removeAttribute("rawRoles")
             user.setAttribute("rawRoles", it.map(JsonSerialization::writeValueAsString))
@@ -322,26 +333,17 @@ class ScimUserEndpoint(
         val fintUserExtClass = FintUserExtension::class.java
         val extension = scimUser.getExtension(fintUserExtClass)
 
-        val excludedFields = setOf("givenName", "familyName")
-
         val attributeFields =
             fintUserExtClass.declaredFields
                 .filter { it.isAnnotationPresent(Attribute::class.java) }
-                .filter { it.name !in excludedFields }
 
         if (extension == null) {
-            user.firstName = null
-            user.lastName = null
-
             attributeFields.forEach { field ->
                 user.removeAttribute(field.name)
             }
 
             return
         }
-
-        user.firstName = extension.givenName
-        user.lastName = extension.familyName
 
         attributeFields.forEach { field ->
             field.isAccessible = true

--- a/keycloak/libs/flais-scim-server/src/main/kotlin/no/novari/keycloak/scim/endpoints/ScimUserEndpoint.kt
+++ b/keycloak/libs/flais-scim-server/src/main/kotlin/no/novari/keycloak/scim/endpoints/ScimUserEndpoint.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode
 import com.unboundid.scim2.common.annotations.Attribute
 import com.unboundid.scim2.common.messages.PatchRequest
 import com.unboundid.scim2.common.types.Email
+import com.unboundid.scim2.common.types.EnterpriseUserExtension
 import com.unboundid.scim2.common.types.Role
 import com.unboundid.scim2.common.utils.ApiConstants
 import com.unboundid.scim2.common.utils.JsonUtils
@@ -44,7 +45,7 @@ import kotlin.streams.asSequence
     description = "User Account",
     name = "User",
     schema = UserResource::class,
-    optionalSchemaExtensions = [FintUserExtension::class],
+    optionalSchemaExtensions = [EnterpriseUserExtension::class, FintUserExtension::class],
 )
 @ResourcePath("Users")
 class ScimUserEndpoint(

--- a/keycloak/libs/flais-scim-server/src/main/kotlin/no/novari/keycloak/scim/endpoints/ScimUserEndpoint.kt
+++ b/keycloak/libs/flais-scim-server/src/main/kotlin/no/novari/keycloak/scim/endpoints/ScimUserEndpoint.kt
@@ -312,7 +312,7 @@ class ScimUserEndpoint(
 
         scimUser.familyName?.let {
             user.lastName = it
-        } ?: {
+        } ?: run {
             user.lastName = null
         }
 

--- a/keycloak/libs/flais-scim-server/src/main/kotlin/no/novari/keycloak/scim/endpoints/ScimUserEndpoint.kt
+++ b/keycloak/libs/flais-scim-server/src/main/kotlin/no/novari/keycloak/scim/endpoints/ScimUserEndpoint.kt
@@ -5,7 +5,6 @@ import com.unboundid.scim2.common.annotations.Attribute
 import com.unboundid.scim2.common.messages.PatchRequest
 import com.unboundid.scim2.common.types.Email
 import com.unboundid.scim2.common.types.EnterpriseUserExtension
-import com.unboundid.scim2.common.types.Name
 import com.unboundid.scim2.common.types.Role
 import com.unboundid.scim2.common.utils.ApiConstants
 import com.unboundid.scim2.common.utils.JsonUtils
@@ -283,11 +282,8 @@ class ScimUserEndpoint(
                     employeeId = user.getFirstAttribute("employeeId")
                     studentNumber = user.getFirstAttribute("studentNumber")
                     userPrincipalName = user.getFirstAttribute("userPrincipalName")
-                    name =
-                        Name().apply {
-                            givenName = user.firstName
-                            familyName = user.lastName
-                        }
+                    givenName = user.firstName
+                    familyName = user.lastName
                 },
             )
         }
@@ -323,35 +319,37 @@ class ScimUserEndpoint(
             user.removeAttribute("roles")
         }
 
-        val fintUserExt = FintUserExtension::class.java
-        val extension = scimUser.getExtension(fintUserExt)
+        val fintUserExtClass = FintUserExtension::class.java
+        val extension = scimUser.getExtension(fintUserExtClass)
 
-        extension?.name?.let { name ->
-            user.firstName = name.givenName
-            user.lastName = name.familyName
-        } ?: run {
-            user.firstName = null
-            user.lastName = null
-        }
+        val excludedFields = setOf("givenName", "familyName")
 
         val attributeFields =
-            fintUserExt.declaredFields
+            fintUserExtClass.declaredFields
                 .filter { it.isAnnotationPresent(Attribute::class.java) }
-                .filter { it.name != "name" }
+                .filter { it.name !in excludedFields }
 
-        extension?.let { ext ->
+        if (extension == null) {
+            user.firstName = null
+            user.lastName = null
+
             attributeFields.forEach { field ->
-                field.isAccessible = true
-                val value = field.get(ext)
-
-                if (value != null) {
-                    user.setSingleAttribute(field.name, value.toString())
-                } else {
-                    user.removeAttribute(field.name)
-                }
+                user.removeAttribute(field.name)
             }
-        } ?: run {
-            attributeFields.forEach { field ->
+
+            return
+        }
+
+        user.firstName = extension.givenName
+        user.lastName = extension.familyName
+
+        attributeFields.forEach { field ->
+            field.isAccessible = true
+            val value = field.get(extension)
+
+            if (value != null) {
+                user.setSingleAttribute(field.name, value.toString())
+            } else {
                 user.removeAttribute(field.name)
             }
         }

--- a/keycloak/libs/flais-scim-server/src/main/kotlin/no/novari/keycloak/scim/endpoints/ScimUserEndpoint.kt
+++ b/keycloak/libs/flais-scim-server/src/main/kotlin/no/novari/keycloak/scim/endpoints/ScimUserEndpoint.kt
@@ -305,18 +305,6 @@ class ScimUserEndpoint(
             user.isEmailVerified = false
         }
 
-        scimUser.givenName?.let {
-            user.firstName = it
-        } ?: run {
-            user.firstName = null
-        }
-
-        scimUser.familyName?.let {
-            user.lastName = it
-        } ?: run {
-            user.lastName = null
-        }
-
         scimUser.roles?.let {
             user.removeAttribute("rawRoles")
             user.setAttribute("rawRoles", it.map(JsonSerialization::writeValueAsString))
@@ -334,17 +322,26 @@ class ScimUserEndpoint(
         val fintUserExtClass = FintUserExtension::class.java
         val extension = scimUser.getExtension(fintUserExtClass)
 
+        val excludedFields = setOf("givenName", "familyName")
+
         val attributeFields =
             fintUserExtClass.declaredFields
                 .filter { it.isAnnotationPresent(Attribute::class.java) }
+                .filter { it.name !in excludedFields }
 
         if (extension == null) {
+            user.firstName = null
+            user.lastName = null
+
             attributeFields.forEach { field ->
                 user.removeAttribute(field.name)
             }
 
             return
         }
+
+        user.firstName = extension.givenName
+        user.lastName = extension.familyName
 
         attributeFields.forEach { field ->
             field.isAccessible = true

--- a/keycloak/libs/flais-scim-server/src/main/kotlin/no/novari/keycloak/scim/endpoints/ScimUserEndpoint.kt
+++ b/keycloak/libs/flais-scim-server/src/main/kotlin/no/novari/keycloak/scim/endpoints/ScimUserEndpoint.kt
@@ -271,11 +271,6 @@ class ScimUserEndpoint(
                         value = user.email
                     },
                 )
-            name =
-                Name().apply {
-                    givenName = user.firstName
-                    familyName = user.lastName
-                }
             roles =
                 user
                     .getAttributeStream("rawRoles")
@@ -288,6 +283,11 @@ class ScimUserEndpoint(
                     employeeId = user.getFirstAttribute("employeeId")
                     studentNumber = user.getFirstAttribute("studentNumber")
                     userPrincipalName = user.getFirstAttribute("userPrincipalName")
+                    name =
+                        Name().apply {
+                            givenName = user.firstName
+                            familyName = user.lastName
+                        }
                 },
             )
         }
@@ -300,14 +300,6 @@ class ScimUserEndpoint(
         user.isEnabled = scimUser.active!!
 
         user.setExternalId(scimUser.externalId)
-
-        scimUser.name?.let { name ->
-            user.firstName = name.givenName
-            user.lastName = name.familyName
-        } ?: run {
-            user.firstName = null
-            user.lastName = null
-        }
 
         scimUser.emails?.find { it.primary }?.let { email ->
             user.email = email.value
@@ -324,7 +316,7 @@ class ScimUserEndpoint(
             user.removeAttribute("roles")
             user.setAttribute(
                 "roles",
-                it.map { it.value },
+                it.map { role -> role.value },
             )
         } ?: run {
             user.removeAttribute("rawRoles")
@@ -332,10 +324,22 @@ class ScimUserEndpoint(
         }
 
         val fintUserExt = FintUserExtension::class.java
+        val extension = scimUser.getExtension(fintUserExt)
+
+        extension?.name?.let { name ->
+            user.firstName = name.givenName
+            user.lastName = name.familyName
+        } ?: run {
+            user.firstName = null
+            user.lastName = null
+        }
+
         val attributeFields =
             fintUserExt.declaredFields
                 .filter { it.isAnnotationPresent(Attribute::class.java) }
-        scimUser.getExtension(fintUserExt)?.let { ext ->
+                .filter { it.name != "name" }
+
+        extension?.let { ext ->
             attributeFields.forEach { field ->
                 field.isAccessible = true
                 val value = field.get(ext)

--- a/keycloak/libs/flais-scim-server/src/main/kotlin/no/novari/keycloak/scim/resources/UserResource.kt
+++ b/keycloak/libs/flais-scim-server/src/main/kotlin/no/novari/keycloak/scim/resources/UserResource.kt
@@ -17,6 +17,36 @@ import java.util.Objects
 class UserResource : BaseScimResource() {
     @Nullable
     @Attribute(
+        description = (
+            "The family name of the User, or Last " +
+                "Name in most Western languages (for example, Jensen given the full " +
+                "name Ms. Barbara J Jensen, III.)."
+        ),
+        isRequired = false,
+        isCaseExact = false,
+        mutability = AttributeDefinition.Mutability.READ_WRITE,
+        returned = AttributeDefinition.Returned.DEFAULT,
+        uniqueness = AttributeDefinition.Uniqueness.NONE,
+    )
+    var familyName: String? = null
+
+    @Nullable
+    @Attribute(
+        description = (
+            "The given name of the User, or First Name " +
+                "in most Western languages (for example, Barbara given the full name " +
+                "Ms. Barbara J Jensen, III.)."
+        ),
+        isRequired = false,
+        isCaseExact = false,
+        mutability = AttributeDefinition.Mutability.READ_WRITE,
+        returned = AttributeDefinition.Returned.DEFAULT,
+        uniqueness = AttributeDefinition.Uniqueness.NONE,
+    )
+    var givenName: String? = null
+
+    @Nullable
+    @Attribute(
         description =
             "Unique identifier for the User typically " +
                 "used by the user to directly authenticate to the service provider.",

--- a/keycloak/libs/flais-scim-server/src/main/kotlin/no/novari/keycloak/scim/resources/UserResource.kt
+++ b/keycloak/libs/flais-scim-server/src/main/kotlin/no/novari/keycloak/scim/resources/UserResource.kt
@@ -31,16 +31,6 @@ class UserResource : BaseScimResource() {
 
     @Nullable
     @Attribute(
-        description = "The components of the user's real name.",
-        isRequired = false,
-        mutability = AttributeDefinition.Mutability.READ_WRITE,
-        returned = AttributeDefinition.Returned.DEFAULT,
-        uniqueness = AttributeDefinition.Uniqueness.NONE,
-    )
-    var name: Name? = null
-
-    @Nullable
-    @Attribute(
         description =
             "A Boolean value indicating the User's " +
                 "administrative status.",
@@ -86,7 +76,6 @@ class UserResource : BaseScimResource() {
 
         val user = o as UserResource
         if (!Objects.equals(userName, user.userName)) return false
-        if (!Objects.equals(name, user.name)) return false
         if (!Objects.equals(active, user.active)) return false
         if (!Objects.equals(emails, user.emails)) return false
         if (!Objects.equals(roles, user.roles)) return false
@@ -98,7 +87,6 @@ class UserResource : BaseScimResource() {
         Objects.hash(
             super.hashCode(),
             userName,
-            name,
             active,
             emails,
             roles,

--- a/keycloak/libs/flais-scim-server/src/main/kotlin/no/novari/keycloak/scim/resources/UserResource.kt
+++ b/keycloak/libs/flais-scim-server/src/main/kotlin/no/novari/keycloak/scim/resources/UserResource.kt
@@ -17,36 +17,6 @@ import java.util.Objects
 class UserResource : BaseScimResource() {
     @Nullable
     @Attribute(
-        description = (
-            "The family name of the User, or Last " +
-                "Name in most Western languages (for example, Jensen given the full " +
-                "name Ms. Barbara J Jensen, III.)."
-        ),
-        isRequired = false,
-        isCaseExact = false,
-        mutability = AttributeDefinition.Mutability.READ_WRITE,
-        returned = AttributeDefinition.Returned.DEFAULT,
-        uniqueness = AttributeDefinition.Uniqueness.NONE,
-    )
-    var familyName: String? = null
-
-    @Nullable
-    @Attribute(
-        description = (
-            "The given name of the User, or First Name " +
-                "in most Western languages (for example, Barbara given the full name " +
-                "Ms. Barbara J Jensen, III.)."
-        ),
-        isRequired = false,
-        isCaseExact = false,
-        mutability = AttributeDefinition.Mutability.READ_WRITE,
-        returned = AttributeDefinition.Returned.DEFAULT,
-        uniqueness = AttributeDefinition.Uniqueness.NONE,
-    )
-    var givenName: String? = null
-
-    @Nullable
-    @Attribute(
         description =
             "Unique identifier for the User typically " +
                 "used by the user to directly authenticate to the service provider.",

--- a/keycloak/libs/flais-scim-server/src/main/kotlin/no/novari/keycloak/scim/resources/UserResource.kt
+++ b/keycloak/libs/flais-scim-server/src/main/kotlin/no/novari/keycloak/scim/resources/UserResource.kt
@@ -6,7 +6,6 @@ import com.unboundid.scim2.common.annotations.Nullable
 import com.unboundid.scim2.common.annotations.Schema
 import com.unboundid.scim2.common.types.AttributeDefinition
 import com.unboundid.scim2.common.types.Email
-import com.unboundid.scim2.common.types.Name
 import com.unboundid.scim2.common.types.Role
 import java.util.Objects
 

--- a/keycloak/libs/flais-scim-server/src/main/kotlin/no/novari/keycloak/scim/types/FintUserExtension.kt
+++ b/keycloak/libs/flais-scim-server/src/main/kotlin/no/novari/keycloak/scim/types/FintUserExtension.kt
@@ -1,6 +1,7 @@
 package no.novari.keycloak.scim.types
 
 import com.unboundid.scim2.common.annotations.Attribute
+import com.unboundid.scim2.common.annotations.Nullable
 import com.unboundid.scim2.common.annotations.Schema
 import com.unboundid.scim2.common.types.AttributeDefinition
 
@@ -10,6 +11,36 @@ import com.unboundid.scim2.common.types.AttributeDefinition
     description = "Fint user extension",
 )
 class FintUserExtension {
+    @Nullable
+    @Attribute(
+        description = (
+            "The given name of the User, or First Name " +
+                "in most Western languages (for example, Barbara given the full name " +
+                "Ms. Barbara J Jensen, III.)."
+        ),
+        isRequired = false,
+        isCaseExact = false,
+        mutability = AttributeDefinition.Mutability.READ_WRITE,
+        returned = AttributeDefinition.Returned.DEFAULT,
+        uniqueness = AttributeDefinition.Uniqueness.NONE,
+    )
+    var givenName: String? = null
+
+    @Nullable
+    @Attribute(
+        description = (
+            "The family name of the User, or Last " +
+                "Name in most Western languages (for example, Jensen given the full " +
+                "name Ms. Barbara J Jensen, III.)."
+        ),
+        isRequired = false,
+        isCaseExact = false,
+        mutability = AttributeDefinition.Mutability.READ_WRITE,
+        returned = AttributeDefinition.Returned.DEFAULT,
+        uniqueness = AttributeDefinition.Uniqueness.NONE,
+    )
+    var familyName: String? = null
+
     @Attribute(
         description = "Employee ID",
         isRequired = false,

--- a/keycloak/libs/flais-scim-server/src/main/kotlin/no/novari/keycloak/scim/types/FintUserExtension.kt
+++ b/keycloak/libs/flais-scim-server/src/main/kotlin/no/novari/keycloak/scim/types/FintUserExtension.kt
@@ -4,7 +4,6 @@ import com.unboundid.scim2.common.annotations.Attribute
 import com.unboundid.scim2.common.annotations.Nullable
 import com.unboundid.scim2.common.annotations.Schema
 import com.unboundid.scim2.common.types.AttributeDefinition
-import com.unboundid.scim2.common.types.Name
 
 @Schema(
     id = "urn:ietf:params:scim:schemas:extension:fint:2.0:User",
@@ -38,11 +37,31 @@ class FintUserExtension {
 
     @Nullable
     @Attribute(
-        description = "The components of the user's real name.",
+        description = (
+            "The family name of the User, or Last " +
+                "Name in most Western languages (for example, Jensen given the full " +
+                "name Ms. Barbara J Jensen, III.)."
+        ),
         isRequired = false,
+        isCaseExact = false,
         mutability = AttributeDefinition.Mutability.READ_WRITE,
         returned = AttributeDefinition.Returned.DEFAULT,
         uniqueness = AttributeDefinition.Uniqueness.NONE,
     )
-    var name: Name? = null
+    var familyName: String? = null
+
+    @Nullable
+    @Attribute(
+        description = (
+            "The given name of the User, or First Name " +
+                "in most Western languages (for example, Barbara given the full name " +
+                "Ms. Barbara J Jensen, III.)."
+        ),
+        isRequired = false,
+        isCaseExact = false,
+        mutability = AttributeDefinition.Mutability.READ_WRITE,
+        returned = AttributeDefinition.Returned.DEFAULT,
+        uniqueness = AttributeDefinition.Uniqueness.NONE,
+    )
+    var givenName: String? = null
 }

--- a/keycloak/libs/flais-scim-server/src/main/kotlin/no/novari/keycloak/scim/types/FintUserExtension.kt
+++ b/keycloak/libs/flais-scim-server/src/main/kotlin/no/novari/keycloak/scim/types/FintUserExtension.kt
@@ -1,8 +1,10 @@
 package no.novari.keycloak.scim.types
 
 import com.unboundid.scim2.common.annotations.Attribute
+import com.unboundid.scim2.common.annotations.Nullable
 import com.unboundid.scim2.common.annotations.Schema
 import com.unboundid.scim2.common.types.AttributeDefinition
+import com.unboundid.scim2.common.types.Name
 
 @Schema(
     id = "urn:ietf:params:scim:schemas:extension:fint:2.0:User",
@@ -33,4 +35,14 @@ class FintUserExtension {
         returned = AttributeDefinition.Returned.DEFAULT,
     )
     var userPrincipalName: String? = null
+
+    @Nullable
+    @Attribute(
+        description = "The components of the user's real name.",
+        isRequired = false,
+        mutability = AttributeDefinition.Mutability.READ_WRITE,
+        returned = AttributeDefinition.Returned.DEFAULT,
+        uniqueness = AttributeDefinition.Uniqueness.NONE,
+    )
+    var name: Name? = null
 }

--- a/keycloak/libs/flais-scim-server/src/main/kotlin/no/novari/keycloak/scim/types/FintUserExtension.kt
+++ b/keycloak/libs/flais-scim-server/src/main/kotlin/no/novari/keycloak/scim/types/FintUserExtension.kt
@@ -1,7 +1,6 @@
 package no.novari.keycloak.scim.types
 
 import com.unboundid.scim2.common.annotations.Attribute
-import com.unboundid.scim2.common.annotations.Nullable
 import com.unboundid.scim2.common.annotations.Schema
 import com.unboundid.scim2.common.types.AttributeDefinition
 
@@ -34,34 +33,4 @@ class FintUserExtension {
         returned = AttributeDefinition.Returned.DEFAULT,
     )
     var userPrincipalName: String? = null
-
-    @Nullable
-    @Attribute(
-        description = (
-            "The family name of the User, or Last " +
-                "Name in most Western languages (for example, Jensen given the full " +
-                "name Ms. Barbara J Jensen, III.)."
-        ),
-        isRequired = false,
-        isCaseExact = false,
-        mutability = AttributeDefinition.Mutability.READ_WRITE,
-        returned = AttributeDefinition.Returned.DEFAULT,
-        uniqueness = AttributeDefinition.Uniqueness.NONE,
-    )
-    var familyName: String? = null
-
-    @Nullable
-    @Attribute(
-        description = (
-            "The given name of the User, or First Name " +
-                "in most Western languages (for example, Barbara given the full name " +
-                "Ms. Barbara J Jensen, III.)."
-        ),
-        isRequired = false,
-        isCaseExact = false,
-        mutability = AttributeDefinition.Mutability.READ_WRITE,
-        returned = AttributeDefinition.Returned.DEFAULT,
-        uniqueness = AttributeDefinition.Uniqueness.NONE,
-    )
-    var givenName: String? = null
 }

--- a/keycloak/libs/flais-scim-server/src/test/kotlin/no/novari/keycloak/scim/application/endpoints/ScimUserEndpointTest.kt
+++ b/keycloak/libs/flais-scim-server/src/test/kotlin/no/novari/keycloak/scim/application/endpoints/ScimUserEndpointTest.kt
@@ -143,11 +143,9 @@ class ScimUserEndpointTest {
         assertEquals("alice.basic@telemark.no", emailNode.get("value").asText())
         assertEquals(true, emailNode.get("primary").asBoolean())
 
-        val extNode = node["urn:ietf:params:scim:schemas:extension:fint:2.0:User"]
-        assertTrue(extNode != null && extNode.isObject)
-
-        assertEquals("Alice", extNode["givenName"].asText())
-        assertEquals("Basic", extNode["familyName"].asText())
+        assertEquals("Alice", node["givenName"].asText())
+        assertEquals("Basic", node["familyName"].asText())
+        assertTrue(node["name"] == null || node["name"].isNull)
 
         val roleNode = node["roles"]
         assertEquals(
@@ -335,10 +333,7 @@ class ScimUserEndpointTest {
                 userId,
                 PatchRequest(
                     listOf(
-                        PatchOperation.replace(
-                            "urn:ietf:params:scim:schemas:extension:fint:2.0:User:givenName",
-                            "new",
-                        ),
+                        PatchOperation.replace("givenName", "new"),
                         PatchOperation.replace(
                             "roles",
                             JsonUtils.getObjectReader().readTree(
@@ -395,96 +390,6 @@ class ScimUserEndpointTest {
     }
 
     @Test
-    fun `patchUser REMOVE extension givenName clears keycloak first name and returns 200`() {
-        templateUser(user)
-
-        every { orgProvider.getMemberById(scimContext.organization, userId) } returns user
-        every { realm.getRole(ScimRoles.SCIM_MANAGED_ROLE) } returns scimRole
-        every { orgProvider.isManagedMember(scimContext.organization, user) } returns true
-        every { orgProvider.getIdentityProviders(scimContext.organization) } returns
-            emptyList<IdentityProviderModel>().stream()
-        every { userProvider.getFederatedIdentitiesStream(realm, user) } returns
-            emptyList<FederatedIdentityModel>().stream()
-
-        val response =
-            endpoint.patchUser(
-                userUriInfo,
-                userId,
-                PatchRequest(
-                    listOf(
-                        PatchOperation.remove(
-                            "urn:ietf:params:scim:schemas:extension:fint:2.0:User:givenName",
-                        ),
-                    ),
-                ),
-            )
-
-        assertEquals(Response.Status.OK.statusCode, response.status)
-
-        verify { user.firstName = null }
-        verify(exactly = 0) { user.removeAttribute("givenName") }
-    }
-
-    @Test
-    fun `patchUser REMOVE extension familyName clears keycloak last name and returns 200`() {
-        templateUser(user)
-
-        every { orgProvider.getMemberById(scimContext.organization, userId) } returns user
-        every { realm.getRole(ScimRoles.SCIM_MANAGED_ROLE) } returns scimRole
-        every { orgProvider.isManagedMember(scimContext.organization, user) } returns true
-        every { orgProvider.getIdentityProviders(scimContext.organization) } returns
-            emptyList<IdentityProviderModel>().stream()
-        every { userProvider.getFederatedIdentitiesStream(realm, user) } returns
-            emptyList<FederatedIdentityModel>().stream()
-
-        val response =
-            endpoint.patchUser(
-                userUriInfo,
-                userId,
-                PatchRequest(
-                    listOf(
-                        PatchOperation.remove(
-                            "urn:ietf:params:scim:schemas:extension:fint:2.0:User:familyName",
-                        ),
-                    ),
-                ),
-            )
-
-        assertEquals(Response.Status.OK.statusCode, response.status)
-
-        verify { user.lastName = null }
-        verify(exactly = 0) { user.removeAttribute("familyName") }
-    }
-
-    @Test
-    fun `updateUser clears first and last name when fint extension is null`() {
-        templateUser(user)
-
-        every { orgProvider.getMemberById(scimContext.organization, userId) } returns user
-        every { realm.getRole(ScimRoles.SCIM_MANAGED_ROLE) } returns scimRole
-        every { user.hasRole(scimRole) } returns true
-        every { orgProvider.isManagedMember(scimContext.organization, user) } returns true
-
-        every { orgProvider.getIdentityProviders(scimContext.organization) } returns
-            emptyList<IdentityProviderModel>().stream()
-        every { userProvider.getFederatedIdentitiesStream(realm, user) } returns
-            emptyList<FederatedIdentityModel>().stream()
-
-        val updatedScimUser =
-            UserResource().apply {
-                userName = "alice.basic@telemark.no"
-                active = true
-                externalId = extId
-            }
-
-        val response = endpoint.updateUser(userUriInfo, userId, updatedScimUser)
-
-        assertEquals(Response.Status.OK.statusCode, response.status)
-
-        verify { user.firstName = null }
-    }
-
-    @Test
     fun `patchUser REMOVE roles removes keycloak roles attribute and returns 200`() {
         templateUser(user)
 
@@ -517,22 +422,21 @@ class ScimUserEndpointTest {
     fun `getUser returns all attributes from fint extension`() {
         templateUser(user)
 
-        val stringExtensionFields =
+        val extensionFields =
             FintUserExtension::class.java.declaredFields
                 .filter { !it.isSynthetic }
-                .filter { it.name !in setOf("givenName", "familyName") }
                 .map { it.name }
                 .sorted()
 
         val expected: Map<String, String?> =
-            stringExtensionFields
+            extensionFields
                 .associateWith { propName -> "value-for-$propName" }
                 .toMutableMap()
                 .apply {
                     if (containsKey("employeeId")) this["employeeId"] = ""
                 }
 
-        stringExtensionFields.forEach { prop ->
+        extensionFields.forEach { prop ->
             every { user.getFirstAttribute(prop) } returns expected[prop]
         }
 
@@ -546,18 +450,15 @@ class ScimUserEndpointTest {
         val extNode = resource.objectNode["urn:ietf:params:scim:schemas:extension:fint:2.0:User"]
         assertTrue(extNode != null && extNode.isObject)
 
-        stringExtensionFields.forEach { prop ->
+        extensionFields.forEach { prop ->
             val jsonValue: String? =
                 extNode.get(prop)?.takeUnless(JsonNode::isNull)?.asText()
 
             assertEquals(expected[prop], jsonValue)
         }
 
-        assertEquals("Alice", extNode["givenName"].asText())
-        assertEquals("Basic", extNode["familyName"].asText())
-
         val jsonFields = extNode.fieldNames().asSequence().toSet()
-        assertEquals((stringExtensionFields + listOf("givenName", "familyName")).toSet(), jsonFields)
+        assertEquals(extensionFields.toSet(), jsonFields)
     }
 
     @Test
@@ -572,33 +473,24 @@ class ScimUserEndpointTest {
         every { orgProvider.getIdentityProviders(scimContext.organization) } returns emptyList<IdentityProviderModel>().stream()
         every { userProvider.getFederatedIdentitiesStream(realm, user) } returns emptyList<FederatedIdentityModel>().stream()
 
-        val stringExtensionFields =
+        val extensionFields =
             FintUserExtension::class.java.declaredFields
-                .asSequence()
                 .filter { !it.isSynthetic }
-                .filter { it.name !in setOf("givenName", "familyName") }
                 .onEach { it.isAccessible = true }
                 .map { it.name }
                 .sorted()
-                .toList()
 
         val expected =
-            stringExtensionFields
+            extensionFields
                 .associateWith { "value-for-$it" }
                 .toMutableMap()
                 .apply {
                     if (containsKey("employeeId")) this["employeeId"] = ""
                 }
 
-        val ext =
-            FintUserExtension().apply {
-                givenName = "Updated"
-                familyName = "Name"
-            }
-
+        val ext = FintUserExtension()
         FintUserExtension::class.java.declaredFields
             .filter { !it.isSynthetic }
-            .filter { it.name !in setOf("givenName", "familyName") }
             .onEach { it.isAccessible = true }
             .forEach { field ->
                 field.set(ext, expected[field.name])
@@ -616,13 +508,8 @@ class ScimUserEndpointTest {
         val response = endpoint.updateUser(userUriInfo, userId, updatedScimUser)
         assertEquals(Response.Status.OK.statusCode, response.status)
 
-        stringExtensionFields.forEach { attr ->
+        extensionFields.forEach { attr ->
             verify { user.setSingleAttribute(attr, expected[attr]) }
         }
-
-        verify { user.firstName = "Updated" }
-        verify { user.lastName = "Name" }
-        verify(exactly = 0) { user.setSingleAttribute(eq("givenName"), any()) }
-        verify(exactly = 0) { user.setSingleAttribute(eq("familyName"), any()) }
     }
 }

--- a/keycloak/libs/flais-scim-server/src/test/kotlin/no/novari/keycloak/scim/application/endpoints/ScimUserEndpointTest.kt
+++ b/keycloak/libs/flais-scim-server/src/test/kotlin/no/novari/keycloak/scim/application/endpoints/ScimUserEndpointTest.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.unboundid.scim2.common.GenericScimResource
 import com.unboundid.scim2.common.messages.PatchOperation
 import com.unboundid.scim2.common.messages.PatchRequest
-import com.unboundid.scim2.common.types.Name
 import com.unboundid.scim2.common.utils.JsonUtils
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
@@ -147,9 +146,8 @@ class ScimUserEndpointTest {
         val extNode = node["urn:ietf:params:scim:schemas:extension:fint:2.0:User"]
         assertTrue(extNode != null && extNode.isObject)
 
-        val nameNode = extNode["name"]
-        assertEquals("Alice", nameNode.get("givenName").asText())
-        assertEquals("Basic", nameNode.get("familyName").asText())
+        assertEquals("Alice", extNode["givenName"].asText())
+        assertEquals("Basic", extNode["familyName"].asText())
 
         val roleNode = node["roles"]
         assertEquals(
@@ -338,7 +336,7 @@ class ScimUserEndpointTest {
                 PatchRequest(
                     listOf(
                         PatchOperation.replace(
-                            "urn:ietf:params:scim:schemas:extension:fint:2.0:User:name.givenName",
+                            "urn:ietf:params:scim:schemas:extension:fint:2.0:User:givenName",
                             "new",
                         ),
                         PatchOperation.replace(
@@ -397,7 +395,7 @@ class ScimUserEndpointTest {
     }
 
     @Test
-    fun `patchUser REMOVE extension name clears keycloak first and last name and returns 200`() {
+    fun `patchUser REMOVE extension givenName clears keycloak first name and returns 200`() {
         templateUser(user)
 
         every { orgProvider.getMemberById(scimContext.organization, userId) } returns user
@@ -415,7 +413,7 @@ class ScimUserEndpointTest {
                 PatchRequest(
                     listOf(
                         PatchOperation.remove(
-                            "urn:ietf:params:scim:schemas:extension:fint:2.0:User:name",
+                            "urn:ietf:params:scim:schemas:extension:fint:2.0:User:givenName",
                         ),
                     ),
                 ),
@@ -424,8 +422,66 @@ class ScimUserEndpointTest {
         assertEquals(Response.Status.OK.statusCode, response.status)
 
         verify { user.firstName = null }
+        verify(exactly = 0) { user.removeAttribute("givenName") }
+    }
+
+    @Test
+    fun `patchUser REMOVE extension familyName clears keycloak last name and returns 200`() {
+        templateUser(user)
+
+        every { orgProvider.getMemberById(scimContext.organization, userId) } returns user
+        every { realm.getRole(ScimRoles.SCIM_MANAGED_ROLE) } returns scimRole
+        every { orgProvider.isManagedMember(scimContext.organization, user) } returns true
+        every { orgProvider.getIdentityProviders(scimContext.organization) } returns
+            emptyList<IdentityProviderModel>().stream()
+        every { userProvider.getFederatedIdentitiesStream(realm, user) } returns
+            emptyList<FederatedIdentityModel>().stream()
+
+        val response =
+            endpoint.patchUser(
+                userUriInfo,
+                userId,
+                PatchRequest(
+                    listOf(
+                        PatchOperation.remove(
+                            "urn:ietf:params:scim:schemas:extension:fint:2.0:User:familyName",
+                        ),
+                    ),
+                ),
+            )
+
+        assertEquals(Response.Status.OK.statusCode, response.status)
+
         verify { user.lastName = null }
-        verify(exactly = 0) { user.removeAttribute("name") }
+        verify(exactly = 0) { user.removeAttribute("familyName") }
+    }
+
+    @Test
+    fun `updateUser clears first and last name when fint extension is null`() {
+        templateUser(user)
+
+        every { orgProvider.getMemberById(scimContext.organization, userId) } returns user
+        every { realm.getRole(ScimRoles.SCIM_MANAGED_ROLE) } returns scimRole
+        every { user.hasRole(scimRole) } returns true
+        every { orgProvider.isManagedMember(scimContext.organization, user) } returns true
+
+        every { orgProvider.getIdentityProviders(scimContext.organization) } returns
+            emptyList<IdentityProviderModel>().stream()
+        every { userProvider.getFederatedIdentitiesStream(realm, user) } returns
+            emptyList<FederatedIdentityModel>().stream()
+
+        val updatedScimUser =
+            UserResource().apply {
+                userName = "alice.basic@telemark.no"
+                active = true
+                externalId = extId
+            }
+
+        val response = endpoint.updateUser(userUriInfo, userId, updatedScimUser)
+
+        assertEquals(Response.Status.OK.statusCode, response.status)
+
+        verify { user.firstName = null }
     }
 
     @Test
@@ -464,7 +520,7 @@ class ScimUserEndpointTest {
         val stringExtensionFields =
             FintUserExtension::class.java.declaredFields
                 .filter { !it.isSynthetic }
-                .filter { it.name != "name" }
+                .filter { it.name !in setOf("givenName", "familyName") }
                 .map { it.name }
                 .sorted()
 
@@ -497,12 +553,11 @@ class ScimUserEndpointTest {
             assertEquals(expected[prop], jsonValue)
         }
 
-        val nameNode = extNode["name"]
-        assertEquals("Alice", nameNode["givenName"].asText())
-        assertEquals("Basic", nameNode["familyName"].asText())
+        assertEquals("Alice", extNode["givenName"].asText())
+        assertEquals("Basic", extNode["familyName"].asText())
 
         val jsonFields = extNode.fieldNames().asSequence().toSet()
-        assertEquals((stringExtensionFields + "name").toSet(), jsonFields)
+        assertEquals((stringExtensionFields + listOf("givenName", "familyName")).toSet(), jsonFields)
     }
 
     @Test
@@ -521,7 +576,7 @@ class ScimUserEndpointTest {
             FintUserExtension::class.java.declaredFields
                 .asSequence()
                 .filter { !it.isSynthetic }
-                .filter { it.name != "name" }
+                .filter { it.name !in setOf("givenName", "familyName") }
                 .onEach { it.isAccessible = true }
                 .map { it.name }
                 .sorted()
@@ -537,16 +592,13 @@ class ScimUserEndpointTest {
 
         val ext =
             FintUserExtension().apply {
-                name =
-                    Name().apply {
-                        givenName = "Updated"
-                        familyName = "Name"
-                    }
+                givenName = "Updated"
+                familyName = "Name"
             }
 
         FintUserExtension::class.java.declaredFields
             .filter { !it.isSynthetic }
-            .filter { it.name != "name" }
+            .filter { it.name !in setOf("givenName", "familyName") }
             .onEach { it.isAccessible = true }
             .forEach { field ->
                 field.set(ext, expected[field.name])
@@ -570,6 +622,7 @@ class ScimUserEndpointTest {
 
         verify { user.firstName = "Updated" }
         verify { user.lastName = "Name" }
-        verify(exactly = 0) { user.setSingleAttribute(eq("name"), any()) }
+        verify(exactly = 0) { user.setSingleAttribute(eq("givenName"), any()) }
+        verify(exactly = 0) { user.setSingleAttribute(eq("familyName"), any()) }
     }
 }

--- a/keycloak/libs/flais-scim-server/src/test/kotlin/no/novari/keycloak/scim/application/endpoints/ScimUserEndpointTest.kt
+++ b/keycloak/libs/flais-scim-server/src/test/kotlin/no/novari/keycloak/scim/application/endpoints/ScimUserEndpointTest.kt
@@ -143,9 +143,11 @@ class ScimUserEndpointTest {
         assertEquals("alice.basic@telemark.no", emailNode.get("value").asText())
         assertEquals(true, emailNode.get("primary").asBoolean())
 
-        assertEquals("Alice", node["givenName"].asText())
-        assertEquals("Basic", node["familyName"].asText())
-        assertTrue(node["name"] == null || node["name"].isNull)
+        val extNode = node["urn:ietf:params:scim:schemas:extension:fint:2.0:User"]
+        assertTrue(extNode != null && extNode.isObject)
+
+        assertEquals("Alice", extNode["givenName"].asText())
+        assertEquals("Basic", extNode["familyName"].asText())
 
         val roleNode = node["roles"]
         assertEquals(
@@ -333,7 +335,10 @@ class ScimUserEndpointTest {
                 userId,
                 PatchRequest(
                     listOf(
-                        PatchOperation.replace("givenName", "new"),
+                        PatchOperation.replace(
+                            "urn:ietf:params:scim:schemas:extension:fint:2.0:User:givenName",
+                            "new",
+                        ),
                         PatchOperation.replace(
                             "roles",
                             JsonUtils.getObjectReader().readTree(
@@ -390,6 +395,96 @@ class ScimUserEndpointTest {
     }
 
     @Test
+    fun `patchUser REMOVE extension givenName clears keycloak first name and returns 200`() {
+        templateUser(user)
+
+        every { orgProvider.getMemberById(scimContext.organization, userId) } returns user
+        every { realm.getRole(ScimRoles.SCIM_MANAGED_ROLE) } returns scimRole
+        every { orgProvider.isManagedMember(scimContext.organization, user) } returns true
+        every { orgProvider.getIdentityProviders(scimContext.organization) } returns
+            emptyList<IdentityProviderModel>().stream()
+        every { userProvider.getFederatedIdentitiesStream(realm, user) } returns
+            emptyList<FederatedIdentityModel>().stream()
+
+        val response =
+            endpoint.patchUser(
+                userUriInfo,
+                userId,
+                PatchRequest(
+                    listOf(
+                        PatchOperation.remove(
+                            "urn:ietf:params:scim:schemas:extension:fint:2.0:User:givenName",
+                        ),
+                    ),
+                ),
+            )
+
+        assertEquals(Response.Status.OK.statusCode, response.status)
+
+        verify { user.firstName = null }
+        verify(exactly = 0) { user.removeAttribute("givenName") }
+    }
+
+    @Test
+    fun `patchUser REMOVE extension familyName clears keycloak last name and returns 200`() {
+        templateUser(user)
+
+        every { orgProvider.getMemberById(scimContext.organization, userId) } returns user
+        every { realm.getRole(ScimRoles.SCIM_MANAGED_ROLE) } returns scimRole
+        every { orgProvider.isManagedMember(scimContext.organization, user) } returns true
+        every { orgProvider.getIdentityProviders(scimContext.organization) } returns
+            emptyList<IdentityProviderModel>().stream()
+        every { userProvider.getFederatedIdentitiesStream(realm, user) } returns
+            emptyList<FederatedIdentityModel>().stream()
+
+        val response =
+            endpoint.patchUser(
+                userUriInfo,
+                userId,
+                PatchRequest(
+                    listOf(
+                        PatchOperation.remove(
+                            "urn:ietf:params:scim:schemas:extension:fint:2.0:User:familyName",
+                        ),
+                    ),
+                ),
+            )
+
+        assertEquals(Response.Status.OK.statusCode, response.status)
+
+        verify { user.lastName = null }
+        verify(exactly = 0) { user.removeAttribute("familyName") }
+    }
+
+    @Test
+    fun `updateUser clears first and last name when fint extension is null`() {
+        templateUser(user)
+
+        every { orgProvider.getMemberById(scimContext.organization, userId) } returns user
+        every { realm.getRole(ScimRoles.SCIM_MANAGED_ROLE) } returns scimRole
+        every { user.hasRole(scimRole) } returns true
+        every { orgProvider.isManagedMember(scimContext.organization, user) } returns true
+
+        every { orgProvider.getIdentityProviders(scimContext.organization) } returns
+            emptyList<IdentityProviderModel>().stream()
+        every { userProvider.getFederatedIdentitiesStream(realm, user) } returns
+            emptyList<FederatedIdentityModel>().stream()
+
+        val updatedScimUser =
+            UserResource().apply {
+                userName = "alice.basic@telemark.no"
+                active = true
+                externalId = extId
+            }
+
+        val response = endpoint.updateUser(userUriInfo, userId, updatedScimUser)
+
+        assertEquals(Response.Status.OK.statusCode, response.status)
+
+        verify { user.firstName = null }
+    }
+
+    @Test
     fun `patchUser REMOVE roles removes keycloak roles attribute and returns 200`() {
         templateUser(user)
 
@@ -422,21 +517,22 @@ class ScimUserEndpointTest {
     fun `getUser returns all attributes from fint extension`() {
         templateUser(user)
 
-        val extensionFields =
+        val stringExtensionFields =
             FintUserExtension::class.java.declaredFields
                 .filter { !it.isSynthetic }
+                .filter { it.name !in setOf("givenName", "familyName") }
                 .map { it.name }
                 .sorted()
 
         val expected: Map<String, String?> =
-            extensionFields
+            stringExtensionFields
                 .associateWith { propName -> "value-for-$propName" }
                 .toMutableMap()
                 .apply {
                     if (containsKey("employeeId")) this["employeeId"] = ""
                 }
 
-        extensionFields.forEach { prop ->
+        stringExtensionFields.forEach { prop ->
             every { user.getFirstAttribute(prop) } returns expected[prop]
         }
 
@@ -450,15 +546,18 @@ class ScimUserEndpointTest {
         val extNode = resource.objectNode["urn:ietf:params:scim:schemas:extension:fint:2.0:User"]
         assertTrue(extNode != null && extNode.isObject)
 
-        extensionFields.forEach { prop ->
+        stringExtensionFields.forEach { prop ->
             val jsonValue: String? =
                 extNode.get(prop)?.takeUnless(JsonNode::isNull)?.asText()
 
             assertEquals(expected[prop], jsonValue)
         }
 
+        assertEquals("Alice", extNode["givenName"].asText())
+        assertEquals("Basic", extNode["familyName"].asText())
+
         val jsonFields = extNode.fieldNames().asSequence().toSet()
-        assertEquals(extensionFields.toSet(), jsonFields)
+        assertEquals((stringExtensionFields + listOf("givenName", "familyName")).toSet(), jsonFields)
     }
 
     @Test
@@ -473,24 +572,33 @@ class ScimUserEndpointTest {
         every { orgProvider.getIdentityProviders(scimContext.organization) } returns emptyList<IdentityProviderModel>().stream()
         every { userProvider.getFederatedIdentitiesStream(realm, user) } returns emptyList<FederatedIdentityModel>().stream()
 
-        val extensionFields =
+        val stringExtensionFields =
             FintUserExtension::class.java.declaredFields
+                .asSequence()
                 .filter { !it.isSynthetic }
+                .filter { it.name !in setOf("givenName", "familyName") }
                 .onEach { it.isAccessible = true }
                 .map { it.name }
                 .sorted()
+                .toList()
 
         val expected =
-            extensionFields
+            stringExtensionFields
                 .associateWith { "value-for-$it" }
                 .toMutableMap()
                 .apply {
                     if (containsKey("employeeId")) this["employeeId"] = ""
                 }
 
-        val ext = FintUserExtension()
+        val ext =
+            FintUserExtension().apply {
+                givenName = "Updated"
+                familyName = "Name"
+            }
+
         FintUserExtension::class.java.declaredFields
             .filter { !it.isSynthetic }
+            .filter { it.name !in setOf("givenName", "familyName") }
             .onEach { it.isAccessible = true }
             .forEach { field ->
                 field.set(ext, expected[field.name])
@@ -508,8 +616,13 @@ class ScimUserEndpointTest {
         val response = endpoint.updateUser(userUriInfo, userId, updatedScimUser)
         assertEquals(Response.Status.OK.statusCode, response.status)
 
-        extensionFields.forEach { attr ->
+        stringExtensionFields.forEach { attr ->
             verify { user.setSingleAttribute(attr, expected[attr]) }
         }
+
+        verify { user.firstName = "Updated" }
+        verify { user.lastName = "Name" }
+        verify(exactly = 0) { user.setSingleAttribute(eq("givenName"), any()) }
+        verify(exactly = 0) { user.setSingleAttribute(eq("familyName"), any()) }
     }
 }

--- a/keycloak/libs/flais-scim-server/src/test/kotlin/no/novari/keycloak/scim/application/endpoints/ScimUserEndpointTest.kt
+++ b/keycloak/libs/flais-scim-server/src/test/kotlin/no/novari/keycloak/scim/application/endpoints/ScimUserEndpointTest.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.unboundid.scim2.common.GenericScimResource
 import com.unboundid.scim2.common.messages.PatchOperation
 import com.unboundid.scim2.common.messages.PatchRequest
+import com.unboundid.scim2.common.types.Name
 import com.unboundid.scim2.common.utils.JsonUtils
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
@@ -143,7 +144,10 @@ class ScimUserEndpointTest {
         assertEquals("alice.basic@telemark.no", emailNode.get("value").asText())
         assertEquals(true, emailNode.get("primary").asBoolean())
 
-        val nameNode = node["name"]
+        val extNode = node["urn:ietf:params:scim:schemas:extension:fint:2.0:User"]
+        assertTrue(extNode != null && extNode.isObject)
+
+        val nameNode = extNode["name"]
         assertEquals("Alice", nameNode.get("givenName").asText())
         assertEquals("Basic", nameNode.get("familyName").asText())
 
@@ -333,7 +337,10 @@ class ScimUserEndpointTest {
                 userId,
                 PatchRequest(
                     listOf(
-                        PatchOperation.replace("name.givenName", "new"),
+                        PatchOperation.replace(
+                            "urn:ietf:params:scim:schemas:extension:fint:2.0:User:name.givenName",
+                            "new",
+                        ),
                         PatchOperation.replace(
                             "roles",
                             JsonUtils.getObjectReader().readTree(
@@ -390,6 +397,38 @@ class ScimUserEndpointTest {
     }
 
     @Test
+    fun `patchUser REMOVE extension name clears keycloak first and last name and returns 200`() {
+        templateUser(user)
+
+        every { orgProvider.getMemberById(scimContext.organization, userId) } returns user
+        every { realm.getRole(ScimRoles.SCIM_MANAGED_ROLE) } returns scimRole
+        every { orgProvider.isManagedMember(scimContext.organization, user) } returns true
+        every { orgProvider.getIdentityProviders(scimContext.organization) } returns
+            emptyList<IdentityProviderModel>().stream()
+        every { userProvider.getFederatedIdentitiesStream(realm, user) } returns
+            emptyList<FederatedIdentityModel>().stream()
+
+        val response =
+            endpoint.patchUser(
+                userUriInfo,
+                userId,
+                PatchRequest(
+                    listOf(
+                        PatchOperation.remove(
+                            "urn:ietf:params:scim:schemas:extension:fint:2.0:User:name",
+                        ),
+                    ),
+                ),
+            )
+
+        assertEquals(Response.Status.OK.statusCode, response.status)
+
+        verify { user.firstName = null }
+        verify { user.lastName = null }
+        verify(exactly = 0) { user.removeAttribute("name") }
+    }
+
+    @Test
     fun `patchUser REMOVE roles removes keycloak roles attribute and returns 200`() {
         templateUser(user)
 
@@ -422,21 +461,22 @@ class ScimUserEndpointTest {
     fun `getUser returns all attributes from fint extension`() {
         templateUser(user)
 
-        val extensionFields =
+        val stringExtensionFields =
             FintUserExtension::class.java.declaredFields
                 .filter { !it.isSynthetic }
+                .filter { it.name != "name" }
                 .map { it.name }
                 .sorted()
 
         val expected: Map<String, String?> =
-            extensionFields
+            stringExtensionFields
                 .associateWith { propName -> "value-for-$propName" }
                 .toMutableMap()
                 .apply {
                     if (containsKey("employeeId")) this["employeeId"] = ""
                 }
 
-        extensionFields.forEach { prop ->
+        stringExtensionFields.forEach { prop ->
             every { user.getFirstAttribute(prop) } returns expected[prop]
         }
 
@@ -450,15 +490,19 @@ class ScimUserEndpointTest {
         val extNode = resource.objectNode["urn:ietf:params:scim:schemas:extension:fint:2.0:User"]
         assertTrue(extNode != null && extNode.isObject)
 
-        extensionFields.forEach { prop ->
+        stringExtensionFields.forEach { prop ->
             val jsonValue: String? =
                 extNode.get(prop)?.takeUnless(JsonNode::isNull)?.asText()
 
             assertEquals(expected[prop], jsonValue)
         }
 
+        val nameNode = extNode["name"]
+        assertEquals("Alice", nameNode["givenName"].asText())
+        assertEquals("Basic", nameNode["familyName"].asText())
+
         val jsonFields = extNode.fieldNames().asSequence().toSet()
-        assertEquals(extensionFields.toSet(), jsonFields)
+        assertEquals((stringExtensionFields + "name").toSet(), jsonFields)
     }
 
     @Test
@@ -473,24 +517,36 @@ class ScimUserEndpointTest {
         every { orgProvider.getIdentityProviders(scimContext.organization) } returns emptyList<IdentityProviderModel>().stream()
         every { userProvider.getFederatedIdentitiesStream(realm, user) } returns emptyList<FederatedIdentityModel>().stream()
 
-        val extensionFields =
+        val stringExtensionFields =
             FintUserExtension::class.java.declaredFields
+                .asSequence()
                 .filter { !it.isSynthetic }
+                .filter { it.name != "name" }
                 .onEach { it.isAccessible = true }
                 .map { it.name }
                 .sorted()
+                .toList()
 
         val expected =
-            extensionFields
+            stringExtensionFields
                 .associateWith { "value-for-$it" }
                 .toMutableMap()
                 .apply {
                     if (containsKey("employeeId")) this["employeeId"] = ""
                 }
 
-        val ext = FintUserExtension()
+        val ext =
+            FintUserExtension().apply {
+                name =
+                    Name().apply {
+                        givenName = "Updated"
+                        familyName = "Name"
+                    }
+            }
+
         FintUserExtension::class.java.declaredFields
             .filter { !it.isSynthetic }
+            .filter { it.name != "name" }
             .onEach { it.isAccessible = true }
             .forEach { field ->
                 field.set(ext, expected[field.name])
@@ -508,8 +564,12 @@ class ScimUserEndpointTest {
         val response = endpoint.updateUser(userUriInfo, userId, updatedScimUser)
         assertEquals(Response.Status.OK.statusCode, response.status)
 
-        extensionFields.forEach { attr ->
+        stringExtensionFields.forEach { attr ->
             verify { user.setSingleAttribute(attr, expected[attr]) }
         }
+
+        verify { user.firstName = "Updated" }
+        verify { user.lastName = "Name" }
+        verify(exactly = 0) { user.setSingleAttribute(eq("name"), any()) }
     }
 }

--- a/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/scim/ProvisionTest.kt
+++ b/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/scim/ProvisionTest.kt
@@ -27,15 +27,20 @@ class ProvisionTest {
                         externalId = "11111111-1111-1111-1111-111111111111",
                         userName = Users.ALICE_TELEMARK,
                         active = true,
-                        givenName = Users.ALICE_TELEMARK,
-                        familyName = Users.BASIC_LAST_NAME,
                         emails = listOf(ScimUser.Email(Users.ALICE_TELEMARK, primary = true)),
                         roles =
                             listOf(
                                 ScimUser.Role("read", "read", "WindowsAzureActiveDirectoryRole", false),
                                 ScimUser.Role("write", "write", "WindowsAzureActiveDirectoryRole", false),
                             ),
-                        fintUserExtension = ScimUser.FintUserExtension("1234", "1234", Users.ALICE_TELEMARK),
+                        fintUserExtension =
+                            ScimUser.FintUserExtension(
+                                Users.ALICE_TELEMARK,
+                                Users.BASIC_LAST_NAME,
+                                "1234",
+                                "1234",
+                                Users.ALICE_TELEMARK,
+                            ),
                     ),
                     ScimUser(
                         schemas =
@@ -45,15 +50,20 @@ class ProvisionTest {
                         externalId = "22222222-2222-2222-2222-222222222222",
                         userName = Users.JON_TELEMARK,
                         active = true,
-                        givenName = Users.JON_FIRST_NAME,
-                        familyName = Users.BASIC_LAST_NAME,
                         emails = listOf(ScimUser.Email(Users.JON_TELEMARK, primary = true)),
                         roles =
                             listOf(
                                 ScimUser.Role("read", "read", "WindowsAzureActiveDirectoryRole", false),
                                 ScimUser.Role("write", "write", "WindowsAzureActiveDirectoryRole", false),
                             ),
-                        fintUserExtension = ScimUser.FintUserExtension("1234", "1234", Users.JON_TELEMARK),
+                        fintUserExtension =
+                            ScimUser.FintUserExtension(
+                                Users.JON_FIRST_NAME,
+                                Users.BASIC_LAST_NAME,
+                                "1234",
+                                "1234",
+                                Users.JON_TELEMARK,
+                            ),
                     ),
                 ),
             Orgs.ROGALAND to
@@ -67,15 +77,20 @@ class ProvisionTest {
                         externalId = "11111111-1111-1111-1111-111111111111",
                         userName = Users.ALICE_ROGALAND,
                         active = true,
-                        givenName = Users.ALICE_FIRST_NAME,
-                        familyName = Users.BASIC_LAST_NAME,
                         emails = listOf(ScimUser.Email(Users.ALICE_ROGALAND, primary = true)),
                         roles =
                             listOf(
                                 ScimUser.Role("read", "read", "WindowsAzureActiveDirectoryRole", false),
                                 ScimUser.Role("write", "write", "WindowsAzureActiveDirectoryRole", false),
                             ),
-                        fintUserExtension = ScimUser.FintUserExtension("1234", "1234", Users.ALICE_ROGALAND),
+                        fintUserExtension =
+                            ScimUser.FintUserExtension(
+                                Users.ALICE_FIRST_NAME,
+                                Users.BASIC_LAST_NAME,
+                                "1234",
+                                "1234",
+                                Users.ALICE_ROGALAND,
+                            ),
                     ),
                     ScimUser(
                         schemas =
@@ -85,15 +100,20 @@ class ProvisionTest {
                         externalId = "22222222-2222-2222-2222-222222222222",
                         userName = Users.JON_ROGALAND,
                         active = true,
-                        givenName = Users.JON_FIRST_NAME,
-                        familyName = Users.BASIC_LAST_NAME,
                         emails = listOf(ScimUser.Email(Users.JON_ROGALAND, primary = true)),
                         roles =
                             listOf(
                                 ScimUser.Role("read", "read", "WindowsAzureActiveDirectoryRole", false),
                                 ScimUser.Role("write", "write", "WindowsAzureActiveDirectoryRole", false),
                             ),
-                        fintUserExtension = ScimUser.FintUserExtension("1234", "1234", Users.JON_ROGALAND),
+                        fintUserExtension =
+                            ScimUser.FintUserExtension(
+                                Users.JON_FIRST_NAME,
+                                Users.BASIC_LAST_NAME,
+                                "1234",
+                                "1234",
+                                Users.JON_ROGALAND,
+                            ),
                     ),
                 ),
         )

--- a/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/scim/ProvisionTest.kt
+++ b/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/scim/ProvisionTest.kt
@@ -27,7 +27,8 @@ class ProvisionTest {
                         externalId = "11111111-1111-1111-1111-111111111111",
                         userName = Users.ALICE_TELEMARK,
                         active = true,
-                        name = ScimUser.Name(Users.ALICE_FIRST_NAME, Users.BASIC_LAST_NAME),
+                        givenName = Users.ALICE_TELEMARK,
+                        familyName = Users.BASIC_LAST_NAME,
                         emails = listOf(ScimUser.Email(Users.ALICE_TELEMARK, primary = true)),
                         roles =
                             listOf(
@@ -44,7 +45,8 @@ class ProvisionTest {
                         externalId = "22222222-2222-2222-2222-222222222222",
                         userName = Users.JON_TELEMARK,
                         active = true,
-                        name = ScimUser.Name(Users.JON_FIRST_NAME, Users.BASIC_LAST_NAME),
+                        givenName = Users.JON_FIRST_NAME,
+                        familyName = Users.BASIC_LAST_NAME,
                         emails = listOf(ScimUser.Email(Users.JON_TELEMARK, primary = true)),
                         roles =
                             listOf(
@@ -65,7 +67,8 @@ class ProvisionTest {
                         externalId = "11111111-1111-1111-1111-111111111111",
                         userName = Users.ALICE_ROGALAND,
                         active = true,
-                        name = ScimUser.Name(Users.ALICE_FIRST_NAME, Users.BASIC_LAST_NAME),
+                        givenName = Users.ALICE_FIRST_NAME,
+                        familyName = Users.BASIC_LAST_NAME,
                         emails = listOf(ScimUser.Email(Users.ALICE_ROGALAND, primary = true)),
                         roles =
                             listOf(
@@ -82,7 +85,8 @@ class ProvisionTest {
                         externalId = "22222222-2222-2222-2222-222222222222",
                         userName = Users.JON_ROGALAND,
                         active = true,
-                        name = ScimUser.Name(Users.JON_FIRST_NAME, Users.BASIC_LAST_NAME),
+                        givenName = Users.JON_FIRST_NAME,
+                        familyName = Users.BASIC_LAST_NAME,
                         emails = listOf(ScimUser.Email(Users.JON_ROGALAND, primary = true)),
                         roles =
                             listOf(

--- a/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/scim/ProvisionedTest.kt
+++ b/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/scim/ProvisionedTest.kt
@@ -44,15 +44,20 @@ class ProvisionedTest {
                         externalId = "11111111-1111-1111-1111-111111111111",
                         userName = Users.ALICE_TELEMARK,
                         active = true,
-                        givenName = Users.ALICE_FIRST_NAME,
-                        familyName = Users.BASIC_LAST_NAME,
                         emails = listOf(ScimUser.Email(Users.ALICE_TELEMARK, primary = true)),
                         roles =
                             listOf(
                                 ScimUser.Role("read", "read", "WindowsAzureActiveDirectoryRole", false),
                                 ScimUser.Role("write", "write", "WindowsAzureActiveDirectoryRole", false),
                             ),
-                        fintUserExtension = ScimUser.FintUserExtension("1234", "1234", Users.ALICE_TELEMARK),
+                        fintUserExtension =
+                            ScimUser.FintUserExtension(
+                                Users.ALICE_FIRST_NAME,
+                                Users.BASIC_LAST_NAME,
+                                "1234",
+                                "1234",
+                                Users.ALICE_TELEMARK,
+                            ),
                     ),
                     ScimUser(
                         schemas =
@@ -62,15 +67,20 @@ class ProvisionedTest {
                         externalId = "22222222-2222-2222-2222-222222222222",
                         userName = Users.JON_TELEMARK,
                         active = true,
-                        givenName = Users.JON_FIRST_NAME,
-                        familyName = Users.BASIC_LAST_NAME,
                         emails = listOf(ScimUser.Email(Users.JON_TELEMARK, primary = true)),
                         roles =
                             listOf(
                                 ScimUser.Role("read", "read", "WindowsAzureActiveDirectoryRole", false),
                                 ScimUser.Role("write", "write", "WindowsAzureActiveDirectoryRole", false),
                             ),
-                        fintUserExtension = ScimUser.FintUserExtension("1234", "1234", Users.JON_TELEMARK),
+                        fintUserExtension =
+                            ScimUser.FintUserExtension(
+                                Users.JON_FIRST_NAME,
+                                Users.BASIC_LAST_NAME,
+                                "1234",
+                                "1234",
+                                Users.JON_TELEMARK,
+                            ),
                     ),
                 ),
             Orgs.ROGALAND to
@@ -84,15 +94,20 @@ class ProvisionedTest {
                         externalId = "11111111-1111-1111-1111-111111111111",
                         userName = Users.ALICE_ROGALAND,
                         active = true,
-                        givenName = Users.ALICE_FIRST_NAME,
-                        familyName = Users.BASIC_LAST_NAME,
                         emails = listOf(ScimUser.Email(Users.ALICE_ROGALAND, primary = true)),
                         roles =
                             listOf(
                                 ScimUser.Role("read", "read", "WindowsAzureActiveDirectoryRole", false),
                                 ScimUser.Role("write", "write", "WindowsAzureActiveDirectoryRole", false),
                             ),
-                        fintUserExtension = ScimUser.FintUserExtension("1234", "1234", Users.ALICE_ROGALAND),
+                        fintUserExtension =
+                            ScimUser.FintUserExtension(
+                                Users.ALICE_FIRST_NAME,
+                                Users.BASIC_LAST_NAME,
+                                "1234",
+                                "1234",
+                                Users.ALICE_ROGALAND,
+                            ),
                     ),
                     ScimUser(
                         schemas =
@@ -102,15 +117,20 @@ class ProvisionedTest {
                         externalId = "22222222-2222-2222-2222-222222222222",
                         userName = Users.JON_ROGALAND,
                         active = true,
-                        givenName = Users.JON_FIRST_NAME,
-                        familyName = Users.BASIC_LAST_NAME,
                         emails = listOf(ScimUser.Email(Users.JON_ROGALAND, primary = true)),
                         roles =
                             listOf(
                                 ScimUser.Role("read", "read", "WindowsAzureActiveDirectoryRole", false),
                                 ScimUser.Role("write", "write", "WindowsAzureActiveDirectoryRole", false),
                             ),
-                        fintUserExtension = ScimUser.FintUserExtension("1234", "1234", Users.JON_ROGALAND),
+                        fintUserExtension =
+                            ScimUser.FintUserExtension(
+                                Users.JON_FIRST_NAME,
+                                Users.BASIC_LAST_NAME,
+                                "1234",
+                                "1234",
+                                Users.JON_ROGALAND,
+                            ),
                     ),
                 ),
         )
@@ -226,8 +246,8 @@ class ProvisionedTest {
                 val newEmails = listOf(ScimUser.Email("new-${user.emails.first().value}", primary = true))
 
                 user.id = KcAdminClient.findUserByUsername(realmRes, user.userName)?.id
-                user.givenName = newGivenName
-                user.familyName = newFamilyName
+                user.fintUserExtension?.givenName = newGivenName
+                user.fintUserExtension?.familyName = newFamilyName
                 user.emails = newEmails
 
                 ScimFlow
@@ -242,8 +262,8 @@ class ProvisionedTest {
 
                 val kcUser = KcAdminClient.findUserByUsername(realmRes, user.userName)
                 assertNotNull(kcUser)
-                assertEquals(user.givenName, kcUser.firstName)
-                assertEquals(user.familyName, kcUser.lastName)
+                assertEquals(user.fintUserExtension?.givenName, kcUser.firstName)
+                assertEquals(user.fintUserExtension?.familyName, kcUser.lastName)
                 assertEquals(user.emails.first().value, kcUser.email)
             }
         }
@@ -327,8 +347,7 @@ class ProvisionedTest {
         val entraCoreUserAttributes =
             JsonObject(
                 mapOf(
-                    "$coreUrn:givenName" to JsonPrimitive("Jeanette"),
-                    "$coreUrn:familyName" to JsonPrimitive("Bergersen"),
+                    "$coreUrn:externalId" to JsonPrimitive("random-id"),
                 ),
             )
 
@@ -351,6 +370,8 @@ class ProvisionedTest {
         val entraFintUserExtensionAttributes =
             JsonObject(
                 mapOf(
+                    "$extensionUrnPrefix:givenName" to JsonPrimitive("Jeanette"),
+                    "$extensionUrnPrefix:familyName" to JsonPrimitive("Bergersen"),
                     "$extensionUrnPrefix:employeeId" to JsonPrimitive("111111111111"),
                     "$extensionUrnPrefix:studentNumber" to JsonPrimitive("111111111111"),
                     "$extensionUrnPrefix:userPrincipalName" to JsonPrimitive("test@test.no"),
@@ -429,11 +450,15 @@ class ProvisionedTest {
                     .filterKeys { it.startsWith(extensionUrnPrefix) }
                     .forEach { (key, value) ->
                         val attributeName = key.substringAfterLast(":")
+                        val actual = value.jsonPrimitive.content
 
-                        assertEquals(
-                            value.jsonPrimitive.content,
-                            kcUser.attributes[attributeName]?.first(),
-                        )
+                        val expected = when (attributeName) {
+                            "givenName" -> kcUser.firstName
+                            "familyName" -> kcUser.lastName
+                            else -> kcUser.attributes[attributeName]?.first()
+                        }
+
+                        assertEquals(expected, actual)
                     }
             }
 

--- a/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/scim/ProvisionedTest.kt
+++ b/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/scim/ProvisionedTest.kt
@@ -44,7 +44,8 @@ class ProvisionedTest {
                         externalId = "11111111-1111-1111-1111-111111111111",
                         userName = Users.ALICE_TELEMARK,
                         active = true,
-                        name = ScimUser.Name(Users.ALICE_FIRST_NAME, Users.BASIC_LAST_NAME),
+                        givenName = Users.ALICE_FIRST_NAME,
+                        familyName = Users.BASIC_LAST_NAME,
                         emails = listOf(ScimUser.Email(Users.ALICE_TELEMARK, primary = true)),
                         roles =
                             listOf(
@@ -61,7 +62,8 @@ class ProvisionedTest {
                         externalId = "22222222-2222-2222-2222-222222222222",
                         userName = Users.JON_TELEMARK,
                         active = true,
-                        name = ScimUser.Name(Users.JON_FIRST_NAME, Users.BASIC_LAST_NAME),
+                        givenName = Users.JON_FIRST_NAME,
+                        familyName = Users.BASIC_LAST_NAME,
                         emails = listOf(ScimUser.Email(Users.JON_TELEMARK, primary = true)),
                         roles =
                             listOf(
@@ -82,7 +84,8 @@ class ProvisionedTest {
                         externalId = "11111111-1111-1111-1111-111111111111",
                         userName = Users.ALICE_ROGALAND,
                         active = true,
-                        name = ScimUser.Name(Users.ALICE_FIRST_NAME, Users.BASIC_LAST_NAME),
+                        givenName = Users.ALICE_FIRST_NAME,
+                        familyName = Users.BASIC_LAST_NAME,
                         emails = listOf(ScimUser.Email(Users.ALICE_ROGALAND, primary = true)),
                         roles =
                             listOf(
@@ -99,7 +102,8 @@ class ProvisionedTest {
                         externalId = "22222222-2222-2222-2222-222222222222",
                         userName = Users.JON_ROGALAND,
                         active = true,
-                        name = ScimUser.Name(Users.JON_FIRST_NAME, Users.BASIC_LAST_NAME),
+                        givenName = Users.JON_FIRST_NAME,
+                        familyName = Users.BASIC_LAST_NAME,
                         emails = listOf(ScimUser.Email(Users.JON_ROGALAND, primary = true)),
                         roles =
                             listOf(
@@ -217,11 +221,13 @@ class ProvisionedTest {
         kc.use {
             users[orgAlias]?.forEach { templateUser ->
                 val user = templateUser.copy()
-                val newName = ScimUser.Name("new", "name")
+                val newGivenName = "newgiven"
+                val newFamilyName = "newfamily"
                 val newEmails = listOf(ScimUser.Email("new-${user.emails.first().value}", primary = true))
 
                 user.id = KcAdminClient.findUserByUsername(realmRes, user.userName)?.id
-                user.name = newName
+                user.givenName = newGivenName
+                user.familyName = newFamilyName
                 user.emails = newEmails
 
                 ScimFlow
@@ -236,8 +242,8 @@ class ProvisionedTest {
 
                 val kcUser = KcAdminClient.findUserByUsername(realmRes, user.userName)
                 assertNotNull(kcUser)
-                assertEquals(user.name.givenName, kcUser.firstName)
-                assertEquals(user.name.familyName, kcUser.lastName)
+                assertEquals(user.givenName, kcUser.firstName)
+                assertEquals(user.familyName, kcUser.lastName)
                 assertEquals(user.emails.first().value, kcUser.email)
             }
         }
@@ -321,8 +327,8 @@ class ProvisionedTest {
         val entraCoreUserAttributes =
             JsonObject(
                 mapOf(
-                    "$coreUrn:name.givenName" to JsonPrimitive("Jeanette"),
-                    "$coreUrn:name.familyName" to JsonPrimitive("Bergersen"),
+                    "$coreUrn:givenName" to JsonPrimitive("Jeanette"),
+                    "$coreUrn:familyName" to JsonPrimitive("Bergersen"),
                 ),
             )
 

--- a/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/scim/ProvisionedTest.kt
+++ b/keycloak/src/test/integration/kotlin/no/novari/test/integration/application/scim/ProvisionedTest.kt
@@ -452,11 +452,12 @@ class ProvisionedTest {
                         val attributeName = key.substringAfterLast(":")
                         val actual = value.jsonPrimitive.content
 
-                        val expected = when (attributeName) {
-                            "givenName" -> kcUser.firstName
-                            "familyName" -> kcUser.lastName
-                            else -> kcUser.attributes[attributeName]?.first()
-                        }
+                        val expected =
+                            when (attributeName) {
+                                "givenName" -> kcUser.firstName
+                                "familyName" -> kcUser.lastName
+                                else -> kcUser.attributes[attributeName]?.first()
+                            }
 
                         assertEquals(expected, actual)
                     }

--- a/keycloak/src/test/integration/kotlin/no/novari/test/integration/utils/ScimFlow.kt
+++ b/keycloak/src/test/integration/kotlin/no/novari/test/integration/utils/ScimFlow.kt
@@ -31,8 +31,6 @@ object ScimFlow {
         var externalId: String,
         var userName: String,
         var active: Boolean,
-        var givenName: String? = null,
-        var familyName: String? = null,
         var emails: List<Email>,
         var roles: List<Role>? = null,
         @SerialName("urn:ietf:params:scim:schemas:extension:fint:2.0:User")
@@ -55,6 +53,8 @@ object ScimFlow {
 
         @Serializable
         data class FintUserExtension(
+            var givenName: String? = null,
+            var familyName: String? = null,
             var employeeId: String? = null,
             var studentNumber: String? = null,
             var userPrincipalName: String? = null,

--- a/keycloak/src/test/integration/kotlin/no/novari/test/integration/utils/ScimFlow.kt
+++ b/keycloak/src/test/integration/kotlin/no/novari/test/integration/utils/ScimFlow.kt
@@ -31,18 +31,13 @@ object ScimFlow {
         var externalId: String,
         var userName: String,
         var active: Boolean,
-        var name: Name,
+        var givenName: String? = null,
+        var familyName: String? = null,
         var emails: List<Email>,
         var roles: List<Role>? = null,
         @SerialName("urn:ietf:params:scim:schemas:extension:fint:2.0:User")
         var fintUserExtension: FintUserExtension? = null,
     ) {
-        @Serializable
-        data class Name(
-            var givenName: String,
-            var familyName: String,
-        )
-
         @Serializable
         data class Email(
             var value: String,


### PR DESCRIPTION
# Summary

Updated the SCIM user representation to avoid using the core `name` complex attribute and instead expose `givenName` and `familyName` as simple attributes on the FINT user extension.

## Why

Microsoft SCIM implementation does not support complex attributes for extensions and has limited support for the core schema. After recent SCIM updates, creating users while specifying the full URN for the core schema caused the `name` complex attribute to break.

To keep Entra provisioning compatible, first and last name are now handled as simple extension attributes instead of through the SCIM core `name` object.

## Changes

- Removed the core SCIM `name` attribute from `UserResource`.
- Added `givenName` and `familyName` to `FintUserExtension`.
- Updated SCIM user creation and updates to map:
  - `givenName` -> Keycloak `firstName`
  - `familyName` -> Keycloak `lastName`
- Prevented `givenName` and `familyName` from being stored as generic Keycloak attributes.
- Updated SCIM responses to return names under:

  ```text
  urn:ietf:params:scim:schemas:extension:fint:2.0:User
  ```

- Updated PATCH handling/tests to use extension paths for name updates/removals.
- Updated Entra SCIM verification configs for Telemark and Rogaland.
- Updated integration test fixtures and assertions to match the new payload shape.
- Replaced unsupported `name.familyName` PATCH verification with a supported email update verification instead.

- Returning `givenName` and `familyName` from the FINT extension.
- Updating Keycloak `firstName` and `lastName` from extension attributes.
- Removing extension `givenName` clears Keycloak `firstName`.
- Removing extension `familyName` clears Keycloak `lastName`.
- Missing FINT extension clears first and last name.
- Provisioning and update flows using the new extension-based name fields.