### PR TITLE
FLA-1658: Add owner configuration and client secret creation to Novari IDP setup

### DIFF
--- a/powershell/fint/Novari-IDP.ps1
+++ b/powershell/fint/Novari-IDP.ps1
@@ -16,6 +16,8 @@ $CreateClaimsMappingPolicyScript = "$PSScriptRoot/modules/Configure-ClaimsMappin
 $ConfigureAppScript = "$PSScriptRoot/modules/Configure-Application.ps1"
 $ConfigureScimScript = "$PSScriptRoot/modules/Configure-ScimProvisioning.ps1"
 $ConfigureAppRolesScript = "$PSScriptRoot/modules/Configure-AppRoles.ps1"
+$ConfigureOwnerScript = "$PSScriptRoot/modules/Configure-Owner.ps1"
+$CreateClientSecretScript = "$PSScriptRoot/modules/Create-ClientSecret.ps1"
 
 $script:LastEnterpriseApplicationResult = $null
 
@@ -121,6 +123,46 @@ function Invoke-ConfigureApplicationRoles {
 
     & $ConfigureAppRolesScript `
         -ApplicationObjectId $ExistingApplicationResult.ApplicationObjectId
+}
+
+
+function Invoke-ConfigureOwner {
+    param(
+        [Parameter(Mandatory = $false)]
+        [object]$ExistingApplicationResult
+    )
+    Assert-NovariEnterpriseApplicationResult -ApplicationResult $ExistingApplicationResult
+
+    & $ConfigureOwnerScript `
+        -ApplicationObjectId $ExistingApplicationResult.ApplicationObjectId `
+        -ServicePrincipalObjectId $ExistingApplicationResult.ServicePrincipalObjectId
+}
+
+
+function Invoke-CreateClientSecret {
+    param(
+        [Parameter(Mandatory = $false)]
+        [object]$ExistingApplicationResult
+    )
+    Assert-NovariEnterpriseApplicationResult -ApplicationResult $ExistingApplicationResult
+
+    $displayName = Read-DefaultedValue `
+        -Prompt "Client secret display name" `
+        -DefaultValue "Keycloak client secret"
+
+    $validityDaysRaw = Read-DefaultedValue `
+        -Prompt "Client secret validity in days" `
+        -DefaultValue "180"
+
+    $validityDays = 0
+    if (-not [int]::TryParse($validityDaysRaw, [ref]$validityDays)) {
+        throw "Client secret validity must be a whole number of days."
+    }
+
+    & $CreateClientSecretScript `
+        -ApplicationObjectId $ExistingApplicationResult.ApplicationObjectId `
+        -DisplayName $displayName `
+        -ValidityDays $validityDays
 }
 
 function Invoke-ConfigureScimProvisioning {

--- a/powershell/fint/README.md
+++ b/powershell/fint/README.md
@@ -1,149 +1,107 @@
-# Overview
+# Novari IDP setup
 
 This directory contains a guided setup script for connecting Microsoft Entra ID to Keycloak.
 
-It is intended for people who need to prepare an Entra Enterprise Application so it can work as an identity provider and provisioning source. In practical terms, the scripts help set up the application, define the information Keycloak should receive about users, and configure automatic user provisioning through SCIM.
+The tool helps prepare an Entra Enterprise Application so it can be used as an identity provider and provisioning source for Keycloak.
 
-## What problem this solves
+Before running the tool, complete the initial setup in [`setup.md`](setup.md).
 
-A integration with Microsoft Entra ID needs several pieces to line up:
+## What the tool configures
 
-- an Enterprise Application in Entra
-- an App Registration connected to that application
-- the right claims so Keycloak receives the user identifiers it expects
-- SCIM provisioning so users and access information can be synchronized
-- application roles that describe what users are allowed to access
+The setup can help configure:
 
-Doing this manually can be repetitive and easy to get slightly wrong. This directory provides a guided setup flow that keeps those steps consistent.
+- an Enterprise Application in Microsoft Entra ID
+- the connected App Registration
+- claims sent from Entra ID to Keycloak
+- SCIM provisioning from Entra ID to Keycloak
+- application roles
+- a client secret for Keycloak
 
-## Start
+## Start the setup
 
-The setup works like this:
+Run the main script:
 
-1. The user starts the main script.
-2. The script connects to Microsoft Graph.
-3. The user either creates a new Enterprise Application or connects to an existing one.
-4. The user chooses setup actions from a menu.
-5. Each menu action delegates to a focused module.
-6. Shared helper files handle things like input prompts, Graph connection checks, retries, and readable console output.
+```powershell
+./Novari-IDP.ps1
+```
 
-The main script is the front door. The modules do the actual setup work. The helpers keep the user experience and safety checks consistent.
+The script connects to Microsoft Graph, lets you create or select an Enterprise Application, and then shows a menu of setup actions.
 
+## Files
 
 ### `Novari-IDP.ps1`
 
-This is the main entry point.
+Main entry point for the setup.
 
-It shows the header, asks for Microsoft Graph connection details, lets the user connect to an existing Enterprise Application if needed, and then presents the setup menu.
-
-Think of this file as the coordinator for the whole setup.
+Use this file to start the tool, connect to Microsoft Graph, select an Enterprise Application, and open the setup menu.
 
 ### `modules/`
 
-This folder contains the main setup actions.
+Setup actions used by the main script.
 
 | File | Purpose |
 |---|---|
-| `Create-EnterpriseApplication.ps1` | Creates the Enterprise Application that represents the integration in Entra. |
-| `Configure-Application.ps1` | Applies the expected settings to the Enterprise Application and App Registration. |
-| `Configure-ClaimsMappingPolicy.ps1` | Defines which user information is sent as claims to. |
-| `Configure-ScimProvisioning.ps1` | Configures SCIM provisioning so users and access information can be synchronized. |
-| `Configure-AppRoles.ps1` | Applies the application roles used to represent access in related services. |
-
-Each module focuses on one part of the overall setup. This makes it easier to review, reuse, and troubleshoot a single area without reading the whole project at once.
+| `Create-EnterpriseApplication.ps1` | Creates the Enterprise Application in Entra. |
+| `Configure-Application.ps1` | Configures the Enterprise Application and App Registration. |
+| `Configure-ClaimsMappingPolicy.ps1` | Configures claims sent to Keycloak. |
+| `Configure-ScimProvisioning.ps1` | Configures SCIM provisioning. |
+| `Configure-AppRoles.ps1` | Configures application roles. |
+| `Create-ClientSecret.ps1` | Creates a new client secret and prints the one-time value. |
 
 ### `helpers/`
 
-This folder contains shared support code used by the main script and modules.
+Shared helper scripts used by the main script and modules.
 
 | File | Purpose |
 |---|---|
-| `ConsoleHelpers.ps1` | Makes console output easier to read. |
-| `EnterpriseApplicationHelpers.ps1` | Validates and displays information about the selected Enterprise Application. |
-| `GenericHelpers.ps1` | Handles common prompts and yes/no style input. |
-| `GraphContext.ps1` | Connects to Microsoft Graph and shows the active connection. |
-| `GraphRetry.ps1` | Adds retry and error handling around Microsoft Graph operations. |
-| `Header.ps1` | Prints the Novari header shown when the tool starts. |
-| `Menu.ps1` | Defines the interactive menu and routes choices to the right setup action. |
-| `RequiredScopes.ps1` | Checks that the Microsoft Graph connection has the expected permissions. |
-
-The helpers are not separate setup steps. They are there to keep the experience predictable and to avoid repeating the same checks in every module.
+| `ConsoleHelpers.ps1` | Formats console output. |
+| `EnterpriseApplicationHelpers.ps1` | Validates and displays the selected Enterprise Application. |
+| `GenericHelpers.ps1` | Handles common prompts. |
+| `GraphContext.ps1` | Connects to Microsoft Graph and shows the active context. |
+| `GraphRetry.ps1` | Adds retry handling around Graph operations. |
+| `Header.ps1` | Prints the startup header. |
+| `Menu.ps1` | Defines the setup menu. |
+| `RequiredScopes.ps1` | Checks required Microsoft Graph permissions. |
 
 ### `app-roles.json`
 
-This file is the role catalogue used when configuring application roles.
+Role catalogue used when configuring application roles.
 
-It describes the roles that can be added to the application, including their names, values, and descriptions. The setup uses this catalogue so that role definitions are managed in one place instead of being scattered across scripts.
+## Menu actions
 
+| Option | Action |
+|---|---|
+| 1 | Create Enterprise Application, shown only when no application is connected in the current session. |
+| 2 | Create and assign Claims Mapping Policy. |
+| 3 | Configure Enterprise Application and App Registration settings. |
+| 4 | Configure SCIM Provisioning. |
+| 5 | Configure Application Roles. |
+| 6 | Configure Application Owner. |
+| 7 | Create Client Secret. |
+| 8 | Show Active Graph Context. |
+| 9 | Show Current Enterprise Application. |
+| 0 | Exit. |
 
-## Conceptual flow
+## Before running
 
-```text
-Start tool
-   ↓
-Connect to Microsoft Graph
-   ↓
-Create or select Enterprise Application
-   ↓
-Configure claims
-   ↓
-Configure application settings
-   ↓
-Configure SCIM provisioning
-   ↓
-Configure roles
-   ↓
-Review in Microsoft Entra
-```
+See [`setup.md`](setup.md) for required prerequisites.
 
-The exact order may vary depending on whether the Enterprise Application already exists, but this is the intended shape of the setup.
+You should also know:
 
-## Key concepts
+- which Entra tenant to use
+- whether to create a new Enterprise Application or reuse an existing one
+- the redirect URI for Keycloak
+- the SCIM endpoint or base URL
+- which Entra attributes to use for employee and student identifiers
+- which organization value to use for organization-specific role values
 
-### Enterprise Application
+## After running
 
-The Enterprise Application is the tenant-side representation of the integration in Microsoft Entra ID. It is the object administrators see and manage when assigning users, configuring provisioning, and reviewing sign-in/provisioning status.
+Review the result in Microsoft Entra and Keycloak:
 
-### App Registration
-
-The App Registration is the application definition behind the Enterprise Application. Some settings live here, such as redirect behavior and token-related configuration.
-
-### Claims
-
-Claims are pieces of user information sent during authentication. This setup includes a claims mapping policy so Keycloak receives the identifiers it expects, such as employee or student identifiers.
-
-### SCIM provisioning
-
-SCIM provisioning is used to synchronize users from Entra to Keycloak.
-
-## Design principles
-
-This directory is organized around a few simple principles:
-
-- **One main entry point:** Start from `Novari-IDP.ps1`.
-- **One responsibility per module:** Each setup area has its own file.
-- **Shared safety checks:** Graph permissions, selected application details, and retry handling are centralized.
-- **Readable interaction:** The tool is menu-driven and prints context while it runs.
-
-## Before running it
-
-Before using the tool, the person running it should know:
-
-- which Microsoft Entra tenant the integration belongs to
-- whether a new Enterprise Application should be created or an existing one should be reused
-- the expected redirect URI for the identity provider setup
-- the SCIM endpoint/base URL
-- which Entra attributes should be used for employee and student identifiers
-- which organization value should be used when applying organization-specific role values
-
-The person running the tool also needs a Microsoft Graph connection with the required rights to create and update the relevant Entra objects.
-
-## What to review after running it
-
-After the setup has been run, review the result in Microsoft Entra and Keycloak:
-
-- the Enterprise Application exists and has the expected name
-- application roles look correct
-- the expected claims are present
-- provisioning is configured and has the expected status
-- SCIM provisioning logs do not show unexpected errors
+- the Enterprise Application has the expected name
+- application roles are correct
+- expected claims are present
+- SCIM provisioning is configured
+- provisioning logs do not show unexpected errors
+- the client secret has been copied into Keycloak and stored securely

--- a/powershell/fint/helpers/Menu.ps1
+++ b/powershell/fint/helpers/Menu.ps1
@@ -13,8 +13,10 @@ function Show-Menu {
     Write-Host "3. Configure Enterprise Application + App Registration settings"
     Write-Host "4. Configure SCIM Provisioning"
     Write-Host "5. Configure Application Roles"
-    Write-Host "6. Show Active Graph Context"
-    Write-Host "7. Show Current Enterprise Application"
+    Write-Host "6. Configure Application Owner"
+    Write-Host "7. Create Client Secret"
+    Write-Host "8. Show Active Graph Context"
+    Write-Host "9. Show Current Enterprise Application"
     Write-Host "0. Exit"
     Write-Host ""
 }
@@ -58,10 +60,20 @@ function Invoke-MenuChoice {
         }
 
         "6" {
-            Show-GraphContext
+            Invoke-ConfigureOwner `
+                -ExistingApplicationResult $script:LastEnterpriseApplicationResult
         }
 
         "7" {
+            Invoke-CreateClientSecret `
+                -ExistingApplicationResult $script:LastEnterpriseApplicationResult
+        }
+
+        "8" {
+            Show-GraphContext
+        }
+
+        "9" {
             Write-EnterpriseApplicationResult -ApplicationResult $script:LastEnterpriseApplicationResult
         }
 
@@ -71,10 +83,10 @@ function Invoke-MenuChoice {
 
         default {
             if ($script:LastEnterpriseApplicationResult) {
-                Write-Host "Invalid option. Please choose 0, 2, 3, 4, 5, 6, or 7." -ForegroundColor Yellow
+                Write-Host "Invalid option. Please choose 0, 2, 3, 4, 5, 6, 7, 8, or 9." -ForegroundColor Yellow
             }
             else {
-                Write-Host "Invalid option. Please choose 0, 1, 2, 3, 4, 5, 6, or 7." -ForegroundColor Yellow
+                Write-Host "Invalid option. Please choose 0, 1, 2, 3, 4, 5, 6, 7, 8, or 9." -ForegroundColor Yellow
             }
         }
     }

--- a/powershell/fint/modules/Configure-Owner.ps1
+++ b/powershell/fint/modules/Configure-Owner.ps1
@@ -1,0 +1,97 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ApplicationObjectId,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ServicePrincipalObjectId
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+. "$PSScriptRoot/../helpers/GraphRetry.ps1"
+. "$PSScriptRoot/../helpers/RequiredScopes.ps1"
+
+Assert-MgContextHasExactlyRequiredScopes -RequiredScopes @(
+    "Application.ReadWrite.OwnedBy"
+)
+
+function Test-DirectoryObjectIsOwner {
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet("applications", "servicePrincipals")]
+        [string]$ResourceType,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ResourceObjectId,
+
+        [Parameter(Mandatory = $true)]
+        [string]$OwnerObjectId
+    )
+
+    $ownersResponse = Invoke-GraphWithRetry `
+        -Method GET `
+        -Uri "https://graph.microsoft.com/v1.0/$ResourceType/$ResourceObjectId/owners?`$select=id"
+
+    $owners = @()
+    if ($ownersResponse.value) {
+        $owners = @($ownersResponse.value)
+    }
+
+    return $null -ne ($owners | Where-Object { $_.id -eq $OwnerObjectId } | Select-Object -First 1)
+}
+
+function Add-DirectoryObjectOwnerIfMissing {
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet("applications", "servicePrincipals")]
+        [string]$ResourceType,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ResourceObjectId,
+
+        [Parameter(Mandatory = $true)]
+        [string]$OwnerObjectId,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ResourceDisplayName,
+
+        [Parameter(Mandatory = $true)]
+        [string]$OwnerDisplayName
+    )
+
+    if (Test-DirectoryObjectIsOwner `
+            -ResourceType $ResourceType `
+            -ResourceObjectId $ResourceObjectId `
+            -OwnerObjectId $OwnerObjectId) {
+        Write-Host "$OwnerDisplayName is already an owner of $ResourceDisplayName."
+        return
+    }
+
+    Write-Host "Adding $OwnerDisplayName as owner of $ResourceDisplayName..."
+
+    $body = @{
+        "@odata.id" = "https://graph.microsoft.com/v1.0/directoryObjects/$OwnerObjectId"
+    }
+
+    Invoke-GraphWithRetry `
+        -Method POST `
+        -Uri "https://graph.microsoft.com/v1.0/$ResourceType/$ResourceObjectId/owners/`$ref" `
+        -BodyJson ($body | ConvertTo-Json -Depth 5) | Out-Null
+
+    Write-Host "Added $OwnerDisplayName as owner of $ResourceDisplayName." -ForegroundColor Green
+}
+
+Add-DirectoryObjectOwnerIfMissing `
+    -ResourceType "applications" `
+    -ResourceObjectId $ApplicationObjectId `
+    -OwnerObjectId $ServicePrincipalObjectId `
+    -ResourceDisplayName "Application Registration $ApplicationObjectId" `
+    -OwnerDisplayName "Enterprise Application service principal $ServicePrincipalObjectId"
+
+Add-DirectoryObjectOwnerIfMissing `
+    -ResourceType "servicePrincipals" `
+    -ResourceObjectId $ServicePrincipalObjectId `
+    -OwnerObjectId $ServicePrincipalObjectId `
+    -ResourceDisplayName "Enterprise Application service principal $ServicePrincipalObjectId" `
+    -OwnerDisplayName "Enterprise Application service principal $ServicePrincipalObjectId"

--- a/powershell/fint/modules/Create-ClientSecret.ps1
+++ b/powershell/fint/modules/Create-ClientSecret.ps1
@@ -1,0 +1,67 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ApplicationObjectId,
+
+    [Parameter(Mandatory = $true)]
+    [string]$DisplayName,
+
+    [Parameter(Mandatory = $true)]
+    [int]$ValidityDays
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+. "$PSScriptRoot/../helpers/GraphRetry.ps1"
+. "$PSScriptRoot/../helpers/RequiredScopes.ps1"
+. "$PSScriptRoot/../helpers/ConsoleHelpers.ps1"
+
+Assert-MgContextHasExactlyRequiredScopes -RequiredScopes @(
+    "Application.ReadWrite.OwnedBy",
+    "Synchronization.ReadWrite.All"
+)
+
+if ([string]::IsNullOrWhiteSpace($DisplayName)) {
+    throw "Client secret display name is required."
+}
+
+if ($ValidityDays -lt 1) {
+    throw "Client secret validity must be at least 1 day."
+}
+
+$endDateTime = [DateTimeOffset]::UtcNow.AddDays($ValidityDays).ToString("yyyy-MM-ddTHH:mm:ssZ")
+
+$body = @{
+    passwordCredential = @{
+        displayName = $DisplayName
+        endDateTime = $endDateTime
+    }
+}
+
+Write-SectionTitle "Creating client secret"
+Write-Host "Application ObjectId: $ApplicationObjectId"
+Write-Host "Display name:         $DisplayName"
+Write-Host "Valid until UTC:      $endDateTime"
+Write-Host ""
+Write-Host "Important: the secret value is only returned once. Copy it before closing this window." -ForegroundColor Yellow
+
+$result = Invoke-GraphWithRetry `
+    -Method POST `
+    -Uri "https://graph.microsoft.com/v1.0/applications/$ApplicationObjectId/addPassword" `
+    -BodyJson ($body | ConvertTo-Json -Depth 10) `
+    -MaxAttempts 1
+
+Write-SectionTitle "Client secret created" -Color Green
+Write-Host "Key ID:          $($result.keyId)"
+Write-Host "Display name:    $DisplayName"
+Write-Host "Valid until UTC: $($result.endDateTime)"
+Write-Host "Secret value:    $($result.secretText)" -ForegroundColor Yellow
+Write-Host ""
+Write-Host "Store the secret value securely now. It cannot be retrieved later from Microsoft Graph." -ForegroundColor Yellow
+
+[pscustomobject]@{
+    KeyId          = $result.keyId
+    DisplayName    = $DisplayName
+    EndDateTime    = $result.endDateTime
+    SecretText     = $result.secretText
+}

--- a/powershell/fint/modules/Create-ClientSecret.ps1
+++ b/powershell/fint/modules/Create-ClientSecret.ps1
@@ -29,6 +29,10 @@ if ($ValidityDays -lt 1) {
     throw "Client secret validity must be at least 1 day."
 }
 
+if ($ValidityDays -gt 720) {
+    throw "Client secret validity cannot exceed 720 days."
+}
+
 $endDateTime = [DateTimeOffset]::UtcNow.AddDays($ValidityDays).ToString("yyyy-MM-ddTHH:mm:ssZ")
 
 $body = @{

--- a/powershell/fint/modules/Create-EnterpriseApplication.ps1
+++ b/powershell/fint/modules/Create-EnterpriseApplication.ps1
@@ -10,8 +10,7 @@ $ErrorActionPreference = "Stop"
 . "$PSScriptRoot/../helpers/RequiredScopes.ps1"
 
 Assert-MgContextHasExactlyRequiredScopes -RequiredScopes @(
-    "Application.ReadWrite.OwnedBy",
-    "Synchronization.ReadWrite.All"
+    "Application.ReadWrite.OwnedBy"
 )
 
 $templateIdNonGallery = "8adf8e6e-67b2-4cf2-a259-e3dc5476c621"

--- a/powershell/fint/setup.md
+++ b/powershell/fint/setup.md
@@ -1,0 +1,49 @@
+# Initial Setup
+
+## Create the temporary PowerShell app registration
+
+1. Create a new app registration for the initial PowerShell setup.
+2. Add the following API permission:
+
+   * `Application.ReadWrite.OwnedBy`
+3. Grant admin consent for the permission.
+4. Create a client secret for the app registration.
+5. Start the setup script.
+
+## Create and configure the Enterprise Application
+
+1. Create the Enterprise Application.
+2. Configure the application owner.
+3. Restart the setup script.
+
+## Configure the final app registration in Entra
+
+1. Open the newly created app registration in Microsoft Entra.
+2. Add the following API permissions:
+
+   * `Application.ReadWrite.OwnedBy`
+   * `Synchronization.ReadWrite.All`
+3. Grant admin consent for the permissions.
+4. Create the initial client secret.
+
+## Complete the setup
+
+1. Connect to the same app registration during login.
+2. Run the required setup steps.
+3. Create a new client secret.
+4. Delete the old client secret.
+5. Save the new client secret securely.
+
+
+## Grant admin consent for delegated permissions
+
+1. Open the app registration
+2. Grant admin consent for all permissions.
+
+## Test login
+
+1. Test the login.
+
+## Clean up
+
+1. Delete the temporary PowerShell app registration created at the beginning.


### PR DESCRIPTION
# PR summary

This PR extends the Novari IDP PowerShell setup flow with two new menu actions:

- Configure the Enterprise Application/App Registration owner
- Create a Keycloak client secret

It adds dedicated modules for owner assignment and client secret generation, wires them into `Novari-IDP.ps1`, and updates the interactive menu numbering accordingly.

The documentation has also been refreshed to:

- describe the setup flow more clearly
- add the new `setup.md` prerequisite guide
- document the new modules
- include the new menu options
- include updated post-run review steps

The Enterprise Application creation step now only requires `Application.ReadWrite.OwnedBy`, while client secret creation keeps the broader permission requirements needed for the full setup.
