### PR TITLE
FLA-1752: Improve logging and remove risky logs in production

### DIFF
--- a/keycloak/docker-compose.yaml
+++ b/keycloak/docker-compose.yaml
@@ -11,7 +11,7 @@ services:
         command: >
             start-dev
             --import-realm
-            --log-level="INFO,org.keycloak.authentication.authenticators:DEBUG,no.novari.authenticator:DEBUG"
+            --log-level="INFO,org.keycloak.authentication.authenticators:DEBUG,no.novari:DEBUG"
         environment:
             KC_HTTP_ENABLED: "true"
             KC_HEALTH_ENABLED: "true"

--- a/keycloak/libs/flais-provider/src/main/kotlin/no/novari/authenticator/org/OrgRedirectorAuthenticator.kt
+++ b/keycloak/libs/flais-provider/src/main/kotlin/no/novari/authenticator/org/OrgRedirectorAuthenticator.kt
@@ -29,7 +29,7 @@ class OrgRedirectorAuthenticator : IdentityProviderAuthenticator() {
             return
         }
 
-        logger.infof("Redirecting to selected provider: %s", idp.alias)
+        logger.infof("Redirecting to selected identity provider. idp=%s", idp.alias)
         doRedirect(context, idp.alias)
     }
 }

--- a/keycloak/libs/flais-provider/src/main/kotlin/no/novari/authenticator/org/OrgSelectionUiAuthenticator.kt
+++ b/keycloak/libs/flais-provider/src/main/kotlin/no/novari/authenticator/org/OrgSelectionUiAuthenticator.kt
@@ -19,7 +19,12 @@ class OrgSelectionUiAuthenticator : Authenticator {
     override fun authenticate(context: AuthenticationFlowContext) {
         val clientOrgAccessProvider = context.session.getProvider(ClientOrgAccessProvider::class.java)
         val organizations = clientOrgAccessProvider.getAllowedOrgs(context)
-        logger.debugf("Found orgs: %s", organizations)
+        logger.debugf(
+            "Found allowed organizations. client=%s count=%d aliases=%s",
+            context.authenticationSession.client.clientId,
+            organizations.size,
+            organizations.map { it.alias },
+        )
 
         context.authenticationSession.getAuthNote(Details.ORG_ID)?.let {
             organizations.find { org -> org.id == it }?.let { org ->
@@ -46,7 +51,6 @@ class OrgSelectionUiAuthenticator : Authenticator {
         val formData = context.httpRequest.decodedFormParameters
 
         val selectedOrg = formData.getFirst("selected_org")
-        logger.infof("Selected Organization: %s", selectedOrg)
 
         val clientOrgAccessProvider = context.session.getProvider(ClientOrgAccessProvider::class.java)
         val organizations = clientOrgAccessProvider.getAllowedOrgs(context)
@@ -60,6 +64,11 @@ class OrgSelectionUiAuthenticator : Authenticator {
         }
 
         organizations.find { it.alias == selectedOrg }?.let { org ->
+            logger.infof(
+                "Organization selected. client=%s org=%s",
+                context.authenticationSession.client.clientId,
+                org.alias,
+            )
             context.authenticationSession.setAuthNote(Details.ORG_ID, org.id)
 
             val rememberMe = formData.getFirst(Details.REMEMBER_ME) ?: ""
@@ -70,6 +79,11 @@ class OrgSelectionUiAuthenticator : Authenticator {
             return
         }
 
+        logger.warnf(
+            "Invalid organization selection. client=%s selectedOrg=%s",
+            context.authenticationSession.client.clientId,
+            selectedOrg,
+        )
         context.failure(
             "Selected organization does not have permission to login to this application",
         )

--- a/keycloak/libs/flais-provider/src/main/kotlin/no/novari/mapper/OrgSpecificAttributeMapper.kt
+++ b/keycloak/libs/flais-provider/src/main/kotlin/no/novari/mapper/OrgSpecificAttributeMapper.kt
@@ -63,7 +63,7 @@ class OrgSpecificAttributeMapper :
         keycloakSession: KeycloakSession,
         clientSessionCtx: ClientSessionContext,
     ) {
-        logger.debugf("Adding org claim to token for %s", userSession.user.username)
+        logger.debugf("Adding org claim to token. userId=%s", userSession.user.id)
 
         val value =
             getAttributeValue(

--- a/keycloak/libs/flais-provider/src/main/kotlin/no/novari/mapper/QlikRolesMapper.kt
+++ b/keycloak/libs/flais-provider/src/main/kotlin/no/novari/mapper/QlikRolesMapper.kt
@@ -119,7 +119,7 @@ class QlikRolesMapper :
         keycloakSession: KeycloakSession,
         clientSessionCtx: ClientSessionContext,
     ) {
-        logger.debugf("Adding Qlik roles claim for user=%s", userSession.user.username)
+        logger.debugf("Adding Qlik roles claim. userId=%s", userSession.user.id)
 
         val tenantId =
             getAttributeValue(

--- a/keycloak/libs/flais-provider/src/main/kotlin/no/novari/provider/DefaultClientOrgAccessProvider.kt
+++ b/keycloak/libs/flais-provider/src/main/kotlin/no/novari/provider/DefaultClientOrgAccessProvider.kt
@@ -2,6 +2,7 @@ package no.novari.provider
 
 import no.novari.utils.ClientPermissionAttributes.getBlacklistedOrganizations
 import no.novari.utils.ClientPermissionAttributes.getWhitelistedOrganizations
+import org.jboss.logging.Logger
 import org.keycloak.authentication.AuthenticationFlowContext
 import org.keycloak.models.KeycloakSession
 import org.keycloak.models.OrganizationModel
@@ -10,6 +11,8 @@ import org.keycloak.organization.OrganizationProvider
 class DefaultClientOrgAccessProvider(
     private val session: KeycloakSession,
 ) : ClientOrgAccessProvider {
+    private val logger: Logger = Logger.getLogger(DefaultClientOrgAccessProvider::class.java)
+
     override fun getAllowedOrgs(context: AuthenticationFlowContext): List<OrganizationModel> {
         val client = context.authenticationSession.client
         val orgProvider = session.getProvider(OrganizationProvider::class.java)
@@ -17,13 +20,24 @@ class DefaultClientOrgAccessProvider(
         val whitelist = getWhitelistedOrganizations(client)
         val blacklist = getBlacklistedOrganizations(client)
 
-        return orgProvider.allStream
-            .filter {
-                (whitelist.isEmpty() || whitelist.contains(it.alias)) &&
-                    !blacklist.contains(it.alias) &&
-                    it.isEnabled &&
-                    it.identityProviders.anyMatch { idp -> idp.isEnabled }
-            }.toList()
+        val allowed =
+            orgProvider.allStream
+                .filter {
+                    (whitelist.isEmpty() || whitelist.contains(it.alias)) &&
+                        !blacklist.contains(it.alias) &&
+                        it.isEnabled &&
+                        it.identityProviders.anyMatch { idp -> idp.isEnabled }
+                }.toList()
+
+        logger.debugf(
+            "Resolved allowed organizations for client. client=%s whitelistCount=%d blacklistCount=%d allowedCount=%d",
+            client.clientId,
+            whitelist.size,
+            blacklist.size,
+            allowed.size,
+        )
+
+        return allowed
     }
 
     override fun isOrgAllowed(
@@ -36,8 +50,19 @@ class DefaultClientOrgAccessProvider(
         val whitelist = getWhitelistedOrganizations(client)
         val blacklist = getBlacklistedOrganizations(client)
 
-        return (whitelist.isEmpty() || whitelist.contains(organization.alias)) &&
-            !blacklist.contains(organization.alias)
+        val allowed =
+            (whitelist.isEmpty() || whitelist.contains(organization.alias)) &&
+                !blacklist.contains(organization.alias)
+
+        logger.debugf(
+            "Evaluated organization access. client=%s org=%s enabled=%s allowed=%s",
+            client.clientId,
+            organization.alias,
+            organization.isEnabled,
+            allowed,
+        )
+
+        return allowed
     }
 
     override fun getOrganizationModel(orgId: String): OrganizationModel? =

--- a/keycloak/libs/flais-provider/src/test/kotlin/no/novari/application/provider/ClientOrgAccessProviderTest.kt
+++ b/keycloak/libs/flais-provider/src/test/kotlin/no/novari/application/provider/ClientOrgAccessProviderTest.kt
@@ -63,6 +63,7 @@ class ClientOrgAccessProviderTest {
 
         every { context.authenticationSession } returns authSession
         every { authSession.client } returns client
+        every { client.clientId } returns "test-client"
         every { session.getProvider(OrganizationProvider::class.java) } returns orgProvider
 
         provider = DefaultClientOrgAccessProvider(session)

--- a/keycloak/libs/flais-scim-server/src/main/kotlin/no/novari/keycloak/scim/authentication/Authenticator.kt
+++ b/keycloak/libs/flais-scim-server/src/main/kotlin/no/novari/keycloak/scim/authentication/Authenticator.kt
@@ -3,8 +3,11 @@ package no.novari.keycloak.scim.authentication
 import jakarta.ws.rs.NotAuthorizedException
 import jakarta.ws.rs.core.HttpHeaders
 import no.novari.keycloak.scim.context.ScimContext
+import org.jboss.logging.Logger
 
 object Authenticator {
+    private val logger: Logger = Logger.getLogger(Authenticator::class.java)
+
     fun verifyAuthenticated(
         scimContext: ScimContext,
         validatorRegistry: JwtValidatorRegistry,
@@ -16,11 +19,21 @@ object Authenticator {
 
         val authorization = context.requestHeaders.getHeaderString(HttpHeaders.AUTHORIZATION)
         if (authorization == null || !authorization.startsWith("Bearer ")) {
+            logger.warnf(
+                "SCIM authentication failed: missing or invalid Authorization header. org=%s realm=%s",
+                scimContext.organization.alias,
+                scimContext.realm.name,
+            )
             throw NotAuthorizedException("Missing or invalid Authorization header")
         }
 
         val token = authorization.substringAfter("Bearer ")
         if (!validatorRegistry.getOrCreate(scimContext.organization.id, scimContext.config).isValid(token)) {
+            logger.warnf(
+                "SCIM authentication failed: invalid bearer token. org=%s realm=%s",
+                scimContext.organization.alias,
+                scimContext.realm.name,
+            )
             throw NotAuthorizedException("Invalid token")
         }
     }

--- a/keycloak/libs/flais-scim-server/src/main/kotlin/no/novari/keycloak/scim/authentication/JwtValidatorRegistry.kt
+++ b/keycloak/libs/flais-scim-server/src/main/kotlin/no/novari/keycloak/scim/authentication/JwtValidatorRegistry.kt
@@ -2,8 +2,11 @@ package no.novari.keycloak.scim.authentication
 
 import com.github.benmanes.caffeine.cache.Caffeine
 import no.novari.keycloak.scim.config.ScimConfig
+import org.jboss.logging.Logger
 
 class JwtValidatorRegistry {
+    private val logger: Logger = Logger.getLogger(JwtValidatorRegistry::class.java)
+
     private val validatorCache =
         Caffeine
             .newBuilder()
@@ -15,6 +18,7 @@ class JwtValidatorRegistry {
         config: ScimConfig,
     ): JwtValidator {
         if (config.authenticationMode == ScimConfig.AuthenticationMode.KEYCLOAK) {
+            logger.warnf("Unsupported SCIM authentication mode requested. authMode=%s", config.authenticationMode)
             error("Keycloak authentication mode is not supported yet")
         }
         return validatorCache.asMap().compute(key) { _, existing ->
@@ -23,7 +27,15 @@ class JwtValidatorRegistry {
                     config.externalJwksUri!!,
                     config.externalIssuer,
                     config.externalAudience,
-                )
+                ).also {
+                    logger.debugf(
+                        "Creating SCIM JWT validator. authMode=%s issuerConfigured=%s audienceConfigured=%s jwksHost=%s",
+                        config.authenticationMode,
+                        config.externalIssuer != null,
+                        config.externalAudience != null,
+                        config.externalJwksUri,
+                    )
+                }
         }!!
     }
 

--- a/keycloak/libs/flais-scim-server/src/main/kotlin/no/novari/keycloak/scim/context/ScimContext.kt
+++ b/keycloak/libs/flais-scim-server/src/main/kotlin/no/novari/keycloak/scim/context/ScimContext.kt
@@ -3,6 +3,7 @@ package no.novari.keycloak.scim.context
 import jakarta.ws.rs.NotFoundException
 import no.novari.keycloak.scim.config.OrganizationScimConfig
 import no.novari.keycloak.scim.config.ScimConfig
+import org.jboss.logging.Logger
 import org.keycloak.models.KeycloakSession
 import org.keycloak.models.OrganizationModel
 import org.keycloak.models.RealmModel
@@ -15,6 +16,8 @@ class ScimContext internal constructor(
     val orgProvider: OrganizationProvider,
     val organization: OrganizationModel,
 )
+
+private val logger: Logger = Logger.getLogger(ScimContext::class.java)
 
 fun createScimContext(
     session: KeycloakSession,
@@ -31,7 +34,16 @@ fun createScimContext(
             ?: throw NotFoundException("Organization not found")
 
     val config = OrganizationScimConfig(organization)
-    config.validateConfig()
+    runCatching {
+        config.validateConfig()
+    }.onFailure {
+        logger.warnf(it, "Invalid SCIM configuration. organizationId=%s", organizationId)
+    }.getOrThrow()
+
+    logger.debugf(
+        "Resolved SCIM context. organizationId=%s",
+        organizationId,
+    )
 
     return ScimContext(
         config,

--- a/keycloak/libs/flais-scim-server/src/main/kotlin/no/novari/keycloak/scim/endpoints/ScimUserEndpoint.kt
+++ b/keycloak/libs/flais-scim-server/src/main/kotlin/no/novari/keycloak/scim/endpoints/ScimUserEndpoint.kt
@@ -36,6 +36,7 @@ import no.novari.keycloak.scim.utils.EntraScimTransformer
 import no.novari.keycloak.scim.utils.ResourcePath
 import no.novari.keycloak.scim.utils.ResourceTypeDefinitionUtil.createResourceTypeDefinition
 import no.novari.keycloak.scim.utils.ScimRoles
+import org.jboss.logging.Logger
 import org.keycloak.models.FederatedIdentityModel
 import org.keycloak.models.UserModel
 import org.keycloak.util.JsonSerialization
@@ -51,11 +52,20 @@ import kotlin.streams.asSequence
 class ScimUserEndpoint(
     private val scimContext: ScimContext,
 ) {
+    private val logger: Logger = Logger.getLogger(ScimUserEndpoint::class.java)
+
     @GET
     @Produces(ApiConstants.MEDIA_TYPE_SCIM, MediaType.APPLICATION_JSON)
     fun getUsers(
         @Context uriInfo: UriInfo,
     ): Response {
+        logger.debugf(
+            "SCIM user search requested. org=%s filter=%s startIndex=%s count=%s",
+            scimContext.organization.alias,
+            uriInfo.queryParameters.getFirst(ApiConstants.QUERY_PARAMETER_FILTER),
+            uriInfo.queryParameters.getFirst(ApiConstants.QUERY_PARAMETER_PAGE_START_INDEX),
+            uriInfo.queryParameters.getFirst(ApiConstants.QUERY_PARAMETER_PAGE_SIZE),
+        )
         val searchHandler = SearchHandler<UserResource>(RESOURCE_TYPE_DEFINITION, uriInfo)
         val scimRole =
             requireNotNull(scimContext.realm.getRole(ScimRoles.SCIM_MANAGED_ROLE)) {
@@ -73,6 +83,7 @@ class ScimUserEndpoint(
                 .map { translateUser(it) }
                 .asSequence()
         val searchResult = searchHandler.createSearchResult(userResources)
+        logger.debugf("SCIM user search completed. org=%s", scimContext.organization.alias)
         return Response.ok(searchResult).build()
     }
 
@@ -86,16 +97,19 @@ class ScimUserEndpoint(
         val user =
             scimContext.orgProvider
                 .getMemberById(scimContext.organization, id)
-                ?: return Response
-                    .status(Response.Status.NOT_FOUND)
-                    .type(ApiConstants.MEDIA_TYPE_SCIM)
-                    .entity(
-                        mapOf(
-                            "schemas" to listOf("urn:ietf:params:scim:api:messages:2.0:Error"),
-                            "status" to 404,
-                            "detail" to "No user found with id $id",
-                        ),
-                    ).build()
+                ?: run {
+                    logger.debugf("SCIM user lookup returned no result. org=%s userId=%s", scimContext.organization.alias, id)
+                    return Response
+                        .status(Response.Status.NOT_FOUND)
+                        .type(ApiConstants.MEDIA_TYPE_SCIM)
+                        .entity(
+                            mapOf(
+                                "schemas" to listOf("urn:ietf:params:scim:api:messages:2.0:Error"),
+                                "status" to 404,
+                                "detail" to "No user found with id $id",
+                            ),
+                        ).build()
+                }
         assertUserScimManaged(user)
 
         val scimUser =
@@ -126,9 +140,11 @@ class ScimUserEndpoint(
 
         val userProvider = scimContext.session.users()
         if (userProvider.getUserById(scimContext.realm, scimUser.userName) != null) {
+            logger.warnf("SCIM user create conflict. org=%s", scimContext.organization.alias)
             return Response.status(Response.Status.CONFLICT).build()
         }
 
+        logger.debugf("Creating SCIM user. org=%s", scimContext.organization.alias)
         val user = userProvider.addUser(scimContext.realm, scimUser.userName)
         val scimRole =
             requireNotNull(scimContext.realm.getRole(ScimRoles.SCIM_MANAGED_ROLE)) {
@@ -139,6 +155,8 @@ class ScimUserEndpoint(
 
         scimContext.orgProvider.addManagedMember(scimContext.organization, user)
         updateUserIdpLinking(user)
+
+        logger.infof("SCIM user created. org=%s userId=%s", scimContext.organization.alias, user.id)
 
         val result =
             translateUser(user).let {
@@ -175,6 +193,7 @@ class ScimUserEndpoint(
 
         updateUserModel(user, updatedScimUser)
         updateUserIdpLinking(user)
+        logger.infof("SCIM user replaced. org=%s userId=%s", scimContext.organization.alias, user.id)
 
         val result =
             translateUser(user).let {
@@ -224,6 +243,7 @@ class ScimUserEndpoint(
 
         updateUserModel(user, scimUser)
         updateUserIdpLinking(user)
+        logger.infof("SCIM user patched. org=%s userId=%s", scimContext.organization.alias, user.id)
 
         val result =
             translateUser(user).let {
@@ -250,10 +270,16 @@ class ScimUserEndpoint(
         assertUserScimManaged(user)
 
         if (!scimContext.orgProvider.isManagedMember(scimContext.organization, user)) {
+            logger.warnf(
+                "SCIM delete rejected because user is not an organization managed member. org=%s userId=%s",
+                scimContext.organization.alias,
+                user.id,
+            )
             throw NotFoundException("User is not part of the organization")
         }
 
         scimContext.orgProvider.removeMember(scimContext.organization, user)
+        logger.infof("SCIM user removed from organization. org=%s userId=%s", scimContext.organization.alias, user.id)
         return Response.noContent().build()
     }
 
@@ -373,6 +399,13 @@ class ScimUserEndpoint(
                 }.map { it.alias }
                 .toList()
 
+        logger.debugf(
+            "Resolved federated identity links. org=%s userId=%s providerCount=%d",
+            scimContext.organization.alias,
+            user.id,
+            socialProviders.size,
+        )
+
         socialProviders.forEach { provider ->
             if (userProvider.getFederatedIdentity(scimContext.realm, user, provider) != null) return@forEach
             val federatedIdentity =
@@ -382,6 +415,12 @@ class ScimUserEndpoint(
                     user.username,
                 )
             userProvider.addFederatedIdentity(scimContext.realm, user, federatedIdentity)
+            logger.infof(
+                "Federated identity linked. org=%s userId=%s provider=%s",
+                scimContext.organization.alias,
+                user.id,
+                provider,
+            )
         }
 
         scimContext.session
@@ -390,6 +429,12 @@ class ScimUserEndpoint(
             .filter { !socialProviders.contains(it.identityProvider) }
             .forEach {
                 scimContext.session.users().removeFederatedIdentity(scimContext.realm, user, it.identityProvider)
+                logger.infof(
+                    "Federated identity unlinked. org=%s userId=%s provider=%s",
+                    scimContext.organization.alias,
+                    user.id,
+                    it.identityProvider,
+                )
             }
     }
 
@@ -399,12 +444,22 @@ class ScimUserEndpoint(
                 "SCIM managed role not found"
             }
         if (!user.hasRole(scimRole)) {
+            logger.warnf(
+                "SCIM managed role check failed. org=%s userId=%s",
+                scimContext.organization.alias,
+                user.id,
+            )
             throw ForbiddenException("User is not SCIM-Managed ${user.id}")
         }
     }
 
     private fun assertUserOrganizationManaged(user: UserModel) {
         if (!scimContext.orgProvider.isManagedMember(scimContext.organization, user)) {
+            logger.warnf(
+                "SCIM organization membership check failed. org=%s userId=%s",
+                scimContext.organization.alias,
+                user.id,
+            )
             throw ForbiddenException("User is not part of the organization")
         }
     }

--- a/keycloak/libs/flais-scim-server/src/main/kotlin/no/novari/keycloak/scim/http/BodyLoggingInterceptor.kt
+++ b/keycloak/libs/flais-scim-server/src/main/kotlin/no/novari/keycloak/scim/http/BodyLoggingInterceptor.kt
@@ -18,7 +18,7 @@ class BodyLoggingInterceptor : ReaderInterceptor {
     override fun aroundReadFrom(context: ReaderInterceptorContext): Any {
         val entityBytes = context.inputStream.readAllBytes()
 
-        logger.info(String(entityBytes))
+        logger.debug(String(entityBytes))
 
         context.inputStream = ByteArrayInputStream(entityBytes)
 


### PR DESCRIPTION
## Summary

Improves logging across the Keycloak FLAIS provider and SCIM server by adding more structured and context to logging.

## Changes

- Expanded Keycloak debug logging scope from `no.novari.authenticator` to all `no.novari` packages in the local Docker Compose setup.
- Improved organization selection logging with structured fields such as client ID, organization alias, counts, and invalid selections.
- Added logging to organization access resolution and access evaluation.
- Updated token mapper logs to use `userId` instead of username.
- Added SCIM authentication failure logs for missing, invalid, or unsupported authentication scenarios.
- Added logging around SCIM context resolution and invalid SCIM configuration.
- Added SCIM user endpoint logs for:
  - user searches
  - user lookup misses
  - create conflicts
  - user creation, replacement, patching, and removal
  - organization membership and SCIM-managed role checks
  - federated identity linking and unlinking
- Changed SCIM request body logging from `INFO` to `DEBUG`.
- Updated tests to mock `client.clientId`, which is now required by the new log statements.