### PR TITLE
FLA-1758: Update documentation with new changes to SCIM and mappers

### DIFF
--- a/docs/concepts/scim.md
+++ b/docs/concepts/scim.md
@@ -29,9 +29,11 @@ SCIM does not participate in interactive login, but to provision users before th
 
 ### User creation
 
-- Users may be created in advance via SCIM
+- Users will be created in advance via SCIM
 - Users may also be created implicitly during first broker login
-- Both paths result in the same internal user model
+    - SCIM is required for the following attributes to be populated:
+        - employeeId
+        - studentNumber
 
 ### User updates
 

--- a/docs/config/fint/entra-id/app-registration.md
+++ b/docs/config/fint/entra-id/app-registration.md
@@ -62,6 +62,8 @@ Additional roles required by the application will also be defined here.
 
 To add custom claims to token see [Entra Claims Mapping Policy](/docs/entra/custom-claims.md)
 
+For default setup, we rely on SCIM for provisioning the user with correct attributes. Custom claims mapper is only needed for importing custom attributes from token on login.
+
 To allow custom claims with **Claims Mapping Policy**, update the application manifest.
 
 | Property                 | Value  |

--- a/docs/config/fint/keycloak/identity-providers.md
+++ b/docs/config/fint/keycloak/identity-providers.md
@@ -81,7 +81,6 @@ Some settings may differ depending on the vendor or specific integration.
 
 | Name                             | Mapper type        | Claim        | Target attribute    | Sync mode |
 | -------------------------------- | ------------------ | ------------ | ------------------- | --------- |
-| `map_employee_id_to_employee_id` | Attribute importer | `employeeId` | `employeeId`        | Inherit   |
-| `map_upn_to_user_principal_name` | Attribute importer | `upn`        | `userPrincipalName` | Inherit   |
 | `map_roles_to_roles`             | Attribute importer | `roles`      | `roles`             | Inherit   |
+| `map_upn_to_user_principal_name` | Attribute importer | `upn`        | `userPrincipalName` | Inherit   |
 | `map_oid_to_external_id`         | Attribute importer | `oid`        | `externalId`        | Inherit   |


### PR DESCRIPTION
## Changes

- Documented that SCIM is required to populate `employeeId` and `studentNumber`.
- Added guidance that the default Entra ID setup relies on SCIM for user provisioning and only needs custom claims mapping when importing custom attributes from login tokens.
- Removed the `employeeId` Keycloak identity provider mapper, keeping role, UPN, and OID mappings.