### PR TITLE
FLA-1783: Add validation on affiliation selection

### DIFF
--- a/keycloak/gradle/libs.versions.toml
+++ b/keycloak/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ slf4j = "2.0.18"
 okhttp = "5.4.0"
 
 kover = "0.9.8"
-playwright = "1.60.0"
+playwright = "1.61.0"
 
 scim-server-sdk = "5.0.0"
 nimbusds-jwt = "10.9.1"

--- a/keycloak/libs/flais-theme/src/login/components/LogoDropdownInput.tsx
+++ b/keycloak/libs/flais-theme/src/login/components/LogoDropdownInput.tsx
@@ -28,6 +28,8 @@ export interface LogoDropdownInputProps extends Omit<
   onChange: (id: string) => void;
   placeholder: string;
   i18n: I18n;
+  hasError: boolean
+  errorId: string
 }
 
 const LogoDropdownInputComponent = ({
@@ -38,6 +40,8 @@ const LogoDropdownInputComponent = ({
   onChange,
   placeholder,
   i18n,
+  hasError,
+  errorId,
   className,
   ...rest
 }: LogoDropdownInputProps) => {
@@ -232,12 +236,15 @@ const LogoDropdownInputComponent = ({
           openList();
           inputRef.current?.focus();
         }}
-        className="
-          flex min-h-12 w-full cursor-text items-center gap-2 rounded-md border border-gray-300
-          bg-white px-3 py-2 text-left text-base text-gray-700 hover:bg-gray-50
-          focus-within:z-10 focus-within:border-primary focus-within:outline-none
-          focus-within:ring-1 focus-within:ring-primary sm:min-h-14 sm:px-4
-        "
+        className={`
+  flex min-h-12 w-full cursor-text items-center gap-2 rounded-md border
+  bg-white px-3 py-2 text-left text-base text-gray-700 hover:bg-gray-50
+  focus-within:z-10 focus-within:outline-none sm:min-h-14 sm:px-4
+  ${hasError
+            ? "border-red-500 ring-1 ring-red-500 focus-within:border-red-500 focus-within:ring-red-500"
+            : "border-gray-300 focus-within:border-primary focus-within:ring-1 focus-within:ring-primary"
+          }
+`}
       >
         {selected?.logosUrl && query === selected.label && !isFiltering && (
           <span className="flex h-8 w-8 shrink-0 items-center justify-center overflow-hidden rounded-full">
@@ -255,6 +262,8 @@ const LogoDropdownInputComponent = ({
           id={controlId}
           type="text"
           role="combobox"
+          aria-describedby={errorId}
+          aria-invalid={hasError}
           aria-controls={listboxId}
           aria-expanded={open}
           aria-haspopup="listbox"
@@ -304,70 +313,77 @@ const LogoDropdownInputComponent = ({
         </button>
       </div>
 
-      {open && (
-        <ul
-          ref={listboxRef}
-          id={listboxId}
-          role="listbox"
-          aria-labelledby={controlId}
-          className="
+      {hasError && (
+        <p id={errorId} className="mt-1 text-sm text-red-600">
+          {i18n.msgStr("chooseOrgRequired")}
+        </p>
+      )}
+
+      {
+        open && (
+          <ul
+            ref={listboxRef}
+            id={listboxId}
+            role="listbox"
+            aria-labelledby={controlId}
+            className="
             absolute z-10 mt-1 max-h-50 w-full overflow-auto rounded-md bg-white
             shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:max-h-56
           "
-        >
-          {filteredOptions.length === 0 ? (
-            <li className="px-3 py-2.5 text-base text-gray-500 sm:px-4 sm:py-3">
-              {i18n.msgStr("noResult")}
-            </li>
-          ) : (
-            filteredOptions.map((option, index) => {
-              const isSelected = option.id === value;
-              const isActive = index === activeIndex;
+          >
+            {filteredOptions.length === 0 ? (
+              <li className="px-3 py-2.5 text-base text-gray-500 sm:px-4 sm:py-3">
+                {i18n.msgStr("noResult")}
+              </li>
+            ) : (
+              filteredOptions.map((option, index) => {
+                const isSelected = option.id === value;
+                const isActive = index === activeIndex;
 
-              return (
-                <li
-                  key={option.id}
-                  id={`${listboxId}-${option.id}`}
-                  role="option"
-                  aria-selected={isSelected}
-                  data-option-index={index}
-                  onMouseEnter={() => setActiveIndex(index)}
-                  onPointerDown={(event: PointerEvent<HTMLLIElement>) => {
-                    event.preventDefault();
-                    selectOption(option);
-                  }}
-                  className={`
+                return (
+                  <li
+                    key={option.id}
+                    id={`${listboxId}-${option.id}`}
+                    role="option"
+                    aria-selected={isSelected}
+                    data-option-index={index}
+                    onMouseEnter={() => setActiveIndex(index)}
+                    onPointerDown={(event: PointerEvent<HTMLLIElement>) => {
+                      event.preventDefault();
+                      selectOption(option);
+                    }}
+                    className={`
                     flex w-full cursor-pointer items-center px-3 py-2.5 text-left text-base
                     focus:outline-none sm:px-4 sm:py-3
-                    ${
-                      isSelected
+                    ${isSelected
                         ? "bg-gray-100 font-semibold text-gray-900"
                         : "text-gray-700 hover:bg-gray-50"
-                    }
+                      }
                     ${isActive && !isSelected ? "bg-gray-50" : ""}
                   `}
-                >
-                  {option.logosUrl && (
-                    <span className="flex h-8 w-8 shrink-0 items-center justify-center overflow-hidden rounded-full">
-                      <img
-                        src={option.logosUrl}
-                        alt=""
-                        aria-hidden="true"
-                        className="max-h-full max-w-full object-contain"
-                      />
-                    </span>
-                  )}
+                  >
+                    {option.logosUrl && (
+                      <span className="flex h-8 w-8 shrink-0 items-center justify-center overflow-hidden rounded-full">
+                        <img
+                          src={option.logosUrl}
+                          alt=""
+                          aria-hidden="true"
+                          className="max-h-full max-w-full object-contain"
+                        />
+                      </span>
+                    )}
 
-                  <span className="ml-2 min-w-0 flex-1 truncate">
-                    {option.label}
-                  </span>
-                </li>
-              );
-            })
-          )}
-        </ul>
-      )}
-    </div>
+                    <span className="ml-2 min-w-0 flex-1 truncate">
+                      {option.label}
+                    </span>
+                  </li>
+                );
+              })
+            )}
+          </ul>
+        )
+      }
+    </div >
   );
 };
 

--- a/keycloak/libs/flais-theme/src/login/components/LogoDropdownInput.tsx
+++ b/keycloak/libs/flais-theme/src/login/components/LogoDropdownInput.tsx
@@ -28,8 +28,8 @@ export interface LogoDropdownInputProps extends Omit<
   onChange: (id: string) => void;
   placeholder: string;
   i18n: I18n;
-  hasError: boolean
-  errorId: string
+  hasError: boolean;
+  errorId: string;
 }
 
 const LogoDropdownInputComponent = ({
@@ -240,10 +240,11 @@ const LogoDropdownInputComponent = ({
   flex min-h-12 w-full cursor-text items-center gap-2 rounded-md border
   bg-white px-3 py-2 text-left text-base text-gray-700 hover:bg-gray-50
   focus-within:z-10 focus-within:outline-none sm:min-h-14 sm:px-4
-  ${hasError
-            ? "border-red-500 ring-1 ring-red-500 focus-within:border-red-500 focus-within:ring-red-500"
-            : "border-gray-300 focus-within:border-primary focus-within:ring-1 focus-within:ring-primary"
-          }
+  ${
+    hasError
+      ? "border-red-500 ring-1 ring-red-500 focus-within:border-red-500 focus-within:ring-red-500"
+      : "border-gray-300 focus-within:border-primary focus-within:ring-1 focus-within:ring-primary"
+  }
 `}
       >
         {selected?.logosUrl && query === selected.label && !isFiltering && (
@@ -319,71 +320,70 @@ const LogoDropdownInputComponent = ({
         </p>
       )}
 
-      {
-        open && (
-          <ul
-            ref={listboxRef}
-            id={listboxId}
-            role="listbox"
-            aria-labelledby={controlId}
-            className="
+      {open && (
+        <ul
+          ref={listboxRef}
+          id={listboxId}
+          role="listbox"
+          aria-labelledby={controlId}
+          className="
             absolute z-10 mt-1 max-h-50 w-full overflow-auto rounded-md bg-white
             shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:max-h-56
           "
-          >
-            {filteredOptions.length === 0 ? (
-              <li className="px-3 py-2.5 text-base text-gray-500 sm:px-4 sm:py-3">
-                {i18n.msgStr("noResult")}
-              </li>
-            ) : (
-              filteredOptions.map((option, index) => {
-                const isSelected = option.id === value;
-                const isActive = index === activeIndex;
+        >
+          {filteredOptions.length === 0 ? (
+            <li className="px-3 py-2.5 text-base text-gray-500 sm:px-4 sm:py-3">
+              {i18n.msgStr("noResult")}
+            </li>
+          ) : (
+            filteredOptions.map((option, index) => {
+              const isSelected = option.id === value;
+              const isActive = index === activeIndex;
 
-                return (
-                  <li
-                    key={option.id}
-                    id={`${listboxId}-${option.id}`}
-                    role="option"
-                    aria-selected={isSelected}
-                    data-option-index={index}
-                    onMouseEnter={() => setActiveIndex(index)}
-                    onPointerDown={(event: PointerEvent<HTMLLIElement>) => {
-                      event.preventDefault();
-                      selectOption(option);
-                    }}
-                    className={`
+              return (
+                <li
+                  key={option.id}
+                  id={`${listboxId}-${option.id}`}
+                  role="option"
+                  aria-selected={isSelected}
+                  data-option-index={index}
+                  onMouseEnter={() => setActiveIndex(index)}
+                  onPointerDown={(event: PointerEvent<HTMLLIElement>) => {
+                    event.preventDefault();
+                    selectOption(option);
+                  }}
+                  className={`
                     flex w-full cursor-pointer items-center px-3 py-2.5 text-left text-base
                     focus:outline-none sm:px-4 sm:py-3
-                    ${isSelected
+                    ${
+                      isSelected
                         ? "bg-gray-100 font-semibold text-gray-900"
                         : "text-gray-700 hover:bg-gray-50"
-                      }
+                    }
                     ${isActive && !isSelected ? "bg-gray-50" : ""}
                   `}
-                  >
-                    {option.logosUrl && (
-                      <span className="flex h-8 w-8 shrink-0 items-center justify-center overflow-hidden rounded-full">
-                        <img
-                          src={option.logosUrl}
-                          alt=""
-                          aria-hidden="true"
-                          className="max-h-full max-w-full object-contain"
-                        />
-                      </span>
-                    )}
-
-                    <span className="ml-2 min-w-0 flex-1 truncate">
-                      {option.label}
+                >
+                  {option.logosUrl && (
+                    <span className="flex h-8 w-8 shrink-0 items-center justify-center overflow-hidden rounded-full">
+                      <img
+                        src={option.logosUrl}
+                        alt=""
+                        aria-hidden="true"
+                        className="max-h-full max-w-full object-contain"
+                      />
                     </span>
-                  </li>
-                );
-              })
-            )}
-          </ul>
-        )
-      }
-    </div >
+                  )}
+
+                  <span className="ml-2 min-w-0 flex-1 truncate">
+                    {option.label}
+                  </span>
+                </li>
+              );
+            })
+          )}
+        </ul>
+      )}
+    </div>
   );
 };
 

--- a/keycloak/libs/flais-theme/src/login/components/LogoDropdownInput.tsx
+++ b/keycloak/libs/flais-theme/src/login/components/LogoDropdownInput.tsx
@@ -228,6 +228,12 @@ const LogoDropdownInputComponent = ({
       className={`relative w-full text-left ${className ?? ""}`}
       {...rest}
     >
+      {hasError && (
+        <p id={errorId} className="mt-1 text-sm text-red-600">
+          {i18n.msgStr("chooseOrgRequired")}
+        </p>
+      )}
+
       <input type="hidden" name={name} value={value ?? ""} />
 
       <div
@@ -313,12 +319,6 @@ const LogoDropdownInputComponent = ({
           />
         </button>
       </div>
-
-      {hasError && (
-        <p id={errorId} className="mt-1 text-sm text-red-600">
-          {i18n.msgStr("chooseOrgRequired")}
-        </p>
-      )}
 
       {open && (
         <ul

--- a/keycloak/libs/flais-theme/src/login/components/OrgSelect.tsx
+++ b/keycloak/libs/flais-theme/src/login/components/OrgSelect.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useMemo } from "react";
 import { LogoDropdownInput } from "./LogoDropdownInput.tsx";
 import { getLogoUrl } from "../utils/logo-url.ts";
 import { I18n } from "../i18n.ts";
@@ -13,15 +13,17 @@ export interface OrgSelectProps {
   i18n: I18n;
   organizations: Organization[];
   excludedAliases?: string[];
+  value: string;
+  onChange: (value: string) => void;
 }
 
 const OrgSelectComponent = ({
   i18n,
   organizations,
   excludedAliases = [],
+  value,
+  onChange,
 }: OrgSelectProps) => {
-  const [selectedOrg, setSelectedOrg] = useState<string>("");
-
   const options = useMemo(
     () =>
       organizations
@@ -45,8 +47,8 @@ const OrgSelectComponent = ({
         placeholder={i18n.msgStr("chooseOrg")}
         name="selected_org"
         options={options}
-        onChange={setSelectedOrg}
-        value={selectedOrg}
+        onChange={onChange}
+        value={value}
         i18n={i18n}
       />
     </div>

--- a/keycloak/libs/flais-theme/src/login/components/OrgSelect.tsx
+++ b/keycloak/libs/flais-theme/src/login/components/OrgSelect.tsx
@@ -16,7 +16,7 @@ export interface OrgSelectProps {
   value: string;
   onChange: (value: string) => void;
   hasError: boolean;
-  errorId: string
+  errorId: string;
 }
 
 const OrgSelectComponent = ({
@@ -26,7 +26,7 @@ const OrgSelectComponent = ({
   value,
   onChange,
   hasError,
-  errorId
+  errorId,
 }: OrgSelectProps) => {
   const options = useMemo(
     () =>

--- a/keycloak/libs/flais-theme/src/login/components/OrgSelect.tsx
+++ b/keycloak/libs/flais-theme/src/login/components/OrgSelect.tsx
@@ -15,6 +15,8 @@ export interface OrgSelectProps {
   excludedAliases?: string[];
   value: string;
   onChange: (value: string) => void;
+  hasError: boolean;
+  errorId: string
 }
 
 const OrgSelectComponent = ({
@@ -23,6 +25,8 @@ const OrgSelectComponent = ({
   excludedAliases = [],
   value,
   onChange,
+  hasError,
+  errorId
 }: OrgSelectProps) => {
   const options = useMemo(
     () =>
@@ -50,6 +54,8 @@ const OrgSelectComponent = ({
         onChange={onChange}
         value={value}
         i18n={i18n}
+        hasError={hasError}
+        errorId={errorId}
       />
     </div>
   );

--- a/keycloak/libs/flais-theme/src/login/components/SubmitButton.tsx
+++ b/keycloak/libs/flais-theme/src/login/components/SubmitButton.tsx
@@ -1,14 +1,10 @@
 import React from "react";
 
-export interface SubmitButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+export interface SubmitButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   text: string;
 }
 
-const SubmitButtonComponent = ({
-  text,
-  ...buttonProps
-}: SubmitButtonProps) => {
+const SubmitButtonComponent = ({ text, ...buttonProps }: SubmitButtonProps) => {
   return (
     <button
       type="submit"

--- a/keycloak/libs/flais-theme/src/login/components/SubmitButton.tsx
+++ b/keycloak/libs/flais-theme/src/login/components/SubmitButton.tsx
@@ -5,7 +5,10 @@ export interface SubmitButtonProps {
   disabled?: boolean;
 }
 
-const SubmitButtonComponent = ({ text, disabled = false }: SubmitButtonProps) => {
+const SubmitButtonComponent = ({
+  text,
+  disabled = false,
+}: SubmitButtonProps) => {
   return (
     <button
       type="submit"

--- a/keycloak/libs/flais-theme/src/login/components/SubmitButton.tsx
+++ b/keycloak/libs/flais-theme/src/login/components/SubmitButton.tsx
@@ -1,25 +1,24 @@
 import React from "react";
 
-export interface SubmitButtonProps {
+export interface SubmitButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   text: string;
-  disabled?: boolean;
 }
 
 const SubmitButtonComponent = ({
   text,
-  disabled = false,
+  ...buttonProps
 }: SubmitButtonProps) => {
   return (
     <button
       type="submit"
-      disabled={disabled}
       className="
         w-full rounded-lg bg-primary px-4 py-3 text-sm font-medium uppercase text-white
         sm:py-3.5 sm:text-base
         hover:bg-primary/90
         focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2
-        disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-primary
       "
+      {...buttonProps}
     >
       {text}
     </button>

--- a/keycloak/libs/flais-theme/src/login/components/SubmitButton.tsx
+++ b/keycloak/libs/flais-theme/src/login/components/SubmitButton.tsx
@@ -2,17 +2,20 @@ import React from "react";
 
 export interface SubmitButtonProps {
   text: string;
+  disabled?: boolean;
 }
 
-const SubmitButtonComponent = ({ text }: SubmitButtonProps) => {
+const SubmitButtonComponent = ({ text, disabled = false }: SubmitButtonProps) => {
   return (
     <button
       type="submit"
+      disabled={disabled}
       className="
         w-full rounded-lg bg-primary px-4 py-3 text-sm font-medium uppercase text-white
         sm:py-3.5 sm:text-base
         hover:bg-primary/90
         focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2
+        disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-primary
       "
     >
       {text}

--- a/keycloak/libs/flais-theme/src/login/i18n.ts
+++ b/keycloak/libs/flais-theme/src/login/i18n.ts
@@ -16,6 +16,7 @@ const { useI18n, ofTypeI18n } = i18nBuilder
       noResult: "Ingen treff",
       closeList: "Lukk liste",
       openList: "Åpne liste",
+      chooseOrgRequired: "Velg en tilhørighet for å fortsette"
     },
     en: {
       chooseIdp: "Choose identity provider",
@@ -27,6 +28,7 @@ const { useI18n, ofTypeI18n } = i18nBuilder
       noResult: "No result",
       closeList: "Close list",
       openList: "Open list",
+      chooseOrgRequired: "Please select an affiliation to continue"
     },
   })
   .build();

--- a/keycloak/libs/flais-theme/src/login/i18n.ts
+++ b/keycloak/libs/flais-theme/src/login/i18n.ts
@@ -16,7 +16,7 @@ const { useI18n, ofTypeI18n } = i18nBuilder
       noResult: "Ingen treff",
       closeList: "Lukk liste",
       openList: "Åpne liste",
-      chooseOrgRequired: "Velg en tilhørighet for å fortsette"
+      chooseOrgRequired: "Velg en tilhørighet for å fortsette",
     },
     en: {
       chooseIdp: "Choose identity provider",
@@ -28,7 +28,7 @@ const { useI18n, ofTypeI18n } = i18nBuilder
       noResult: "No result",
       closeList: "Close list",
       openList: "Open list",
-      chooseOrgRequired: "Please select an affiliation to continue"
+      chooseOrgRequired: "Please select an affiliation to continue",
     },
   })
   .build();

--- a/keycloak/libs/flais-theme/src/login/pages/FlaisOrgSelector.tsx
+++ b/keycloak/libs/flais-theme/src/login/pages/FlaisOrgSelector.tsx
@@ -47,6 +47,7 @@ const FlaisOrgSelectorComponent = ({
     if (!selectedOrg) {
       event.preventDefault();
       setShowOrgError(true);
+      document.getElementById("selected_org")?.focus();
     }
   };
 

--- a/keycloak/libs/flais-theme/src/login/pages/FlaisOrgSelector.tsx
+++ b/keycloak/libs/flais-theme/src/login/pages/FlaisOrgSelector.tsx
@@ -23,6 +23,7 @@ const FlaisOrgSelectorComponent = ({
 }: FlaisOrgSelectorProps) => {
   const { organizations, url } = kcContext;
   const [selectedOrg, setSelectedOrg] = useState("");
+  const [showOrgError, setShowOrgError] = useState(false);
 
   const sortByName = <T extends { name: string }>(items: T[]) =>
     [...items].sort((a, b) =>
@@ -42,6 +43,21 @@ const FlaisOrgSelectorComponent = ({
     [organizations],
   );
 
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    if (!selectedOrg) {
+      event.preventDefault();
+      setShowOrgError(true);
+    }
+  };
+
+  const handleOrgChange = (value: string) => {
+    setSelectedOrg(value);
+
+    if (value) {
+      setShowOrgError(false);
+    }
+  };
+
   return (
     <PageWrapper>
       <LoginCard logo={logo}>
@@ -54,18 +70,21 @@ const FlaisOrgSelectorComponent = ({
           className="space-y-5"
           method="POST"
           action={url.registrationAction}
+          onSubmit={handleSubmit}
         >
           <OrgSelect
             i18n={i18n}
             organizations={sortedOrganizations}
             excludedAliases={EXCLUDED_ORG_ALIASES}
             value={selectedOrg}
-            onChange={setSelectedOrg}
+            onChange={handleOrgChange}
+            hasError={showOrgError}
+            errorId={"org-not-selected-error"}
           />
 
           <SubmitButton
             text={i18n.msgStr("continue")}
-            disabled={selectedOrg == ""}
+            data-testid="continue-with-selected-org"
           />
         </form>
 

--- a/keycloak/libs/flais-theme/src/login/pages/FlaisOrgSelector.tsx
+++ b/keycloak/libs/flais-theme/src/login/pages/FlaisOrgSelector.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import logo from "../assets/images/novari_logo.png";
 
 import { I18n } from "../i18n.ts";
@@ -22,6 +22,7 @@ const FlaisOrgSelectorComponent = ({
   i18n,
 }: FlaisOrgSelectorProps) => {
   const { organizations, url } = kcContext;
+  const [selectedOrg, setSelectedOrg] = useState("");
 
   const sortByName = <T extends { name: string }>(items: T[]) =>
     [...items].sort((a, b) =>
@@ -58,9 +59,14 @@ const FlaisOrgSelectorComponent = ({
             i18n={i18n}
             organizations={sortedOrganizations}
             excludedAliases={EXCLUDED_ORG_ALIASES}
+            value={selectedOrg}
+            onChange={setSelectedOrg}
           />
 
-          <SubmitButton text={i18n.msgStr("continue")} />
+          <SubmitButton
+            text={i18n.msgStr("continue")}
+            disabled={selectedOrg == ""}
+          />
         </form>
 
         {otherSignInOptions.length > 0 && (

--- a/keycloak/src/test/system/kotlin/no/novari/test/system/e2e/theme/FlaisLoginThemeTest.kt
+++ b/keycloak/src/test/system/kotlin/no/novari/test/system/e2e/theme/FlaisLoginThemeTest.kt
@@ -58,11 +58,8 @@ class FlaisLoginThemeTest {
         val page = session.page
 
         PwFlow.navigateToLogin(env, page, clientId = Clients.FLAIS_KEYCLOAK_DEMO)
-        PwFlow.submit(page)
 
-        assertThat(page).hasURL(
-            Pattern.compile(env.keycloakServiceUrl()),
-        )
+        assertThat(page.locator("button[type=\"submit\"]")).isDisabled()
     }
 
     private fun assertCallback(

--- a/keycloak/src/test/system/kotlin/no/novari/test/system/e2e/theme/FlaisLoginThemeTest.kt
+++ b/keycloak/src/test/system/kotlin/no/novari/test/system/e2e/theme/FlaisLoginThemeTest.kt
@@ -51,7 +51,7 @@ class FlaisLoginThemeTest {
     }
 
     @TestTemplate
-    fun `login cannot proceed without selecting organization`(
+    fun `login cannot proceed without selecting organization and shows validation error`(
         env: KcEnvironment,
         session: PwEnvironment.Session,
     ) {
@@ -59,7 +59,12 @@ class FlaisLoginThemeTest {
 
         PwFlow.navigateToLogin(env, page, clientId = Clients.FLAIS_KEYCLOAK_DEMO)
 
-        assertThat(page.locator("button[type=\"submit\"]")).isDisabled()
+        val continueButton = page.getByTestId("continue-with-selected-org")
+
+        continueButton.click()
+
+        assertThat(page.locator("#org-not-selected-error"))
+            .hasText("Please select an affiliation to continue")
     }
 
     private fun assertCallback(

--- a/keycloak/src/test/system/kotlin/no/novari/test/system/utils/PwFlow.kt
+++ b/keycloak/src/test/system/kotlin/no/novari/test/system/utils/PwFlow.kt
@@ -5,6 +5,7 @@ import com.microsoft.playwright.Page
 import com.microsoft.playwright.options.AriaRole
 import no.novari.test.common.environment.kc.KcEnvironment
 import no.novari.test.common.utils.KcUrl
+import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
 
 /**
  * Utility functions to simplify Playwright flows in system tests.
@@ -41,6 +42,8 @@ object PwFlow {
     }
 
     fun submit(page: Page) {
-        page.locator("button[type=\"submit\"]").click()
+        val submitButton = page.locator("button[type=\"submit\"]")
+        assertThat(submitButton).isEnabled()
+        submitButton.click()
     }
 }

--- a/keycloak/src/test/system/kotlin/no/novari/test/system/utils/PwFlow.kt
+++ b/keycloak/src/test/system/kotlin/no/novari/test/system/utils/PwFlow.kt
@@ -2,10 +2,10 @@ package no.novari.test.system.utils
 
 import com.microsoft.playwright.Locator
 import com.microsoft.playwright.Page
+import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
 import com.microsoft.playwright.options.AriaRole
 import no.novari.test.common.environment.kc.KcEnvironment
 import no.novari.test.common.utils.KcUrl
-import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
 
 /**
  * Utility functions to simplify Playwright flows in system tests.


### PR DESCRIPTION
## Summary

- Moved organization selection state from `OrgSelect` into `FlaisOrgSelector`.
- Made state from `OrgSelect` by adding `value` and `onChange` props.
- Added client-side validation to prevent continuing without selecting an organization.
- Displayed an accessible validation error message when no organization is selected.
- Added localized validation messages for Norwegian and English.
- Added a test id to the continue button for more stable E2E testing.
- Bumped Playwright from `1.60.0` to `1.61.0`.
- Updated system E2E test for the FLAIS login theme to verify that submitting without an organization shows error.

Fixes #368
