### PR TITLE
FLA-1789: Add new scope for users external object ID

### DIFF
--- a/docs/config/fint/keycloak/client-scopes.md
+++ b/docs/config/fint/keycloak/client-scopes.md
@@ -74,6 +74,26 @@ Configuration of the **Client Scopes**.
 
 ---
 
+## 	external-id
+
+| Setting                             | Value                                                                                            |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------ |
+| Name                                | `external-id`                                                                                    |
+| Description                         | Adds the federated user's external object identifier to tokens for application identity mapping. |
+| Type                                | Default                                                                                          |
+| Protocol                            | OpenID Connect                                                                                   |
+| Display on consent screen           | Off                                                                                              |
+| Include in token scope              | On                                                                                               |
+| Include in OpenID Provider Metadata | On                                                                                               |
+
+### Mappers
+
+| Name               | Mapper type    | Source attribute | Claim              | Tokens                                                |
+| ------------------ | -------------- | ---------------- | ------------------ | ----------------------------------------------------- |
+| `objectidentifier` | User Attribute | `externalId`     | `objectidentifier` | ID token, Access token, Userinfo, Token introspection |
+
+---
+
 ## profile
 
 | Setting                             | Value                         |


### PR DESCRIPTION
Adds a new scope for the federated user's external object identifier so it can be added to tokens.

The external-id does not fit in any of the client scopes. For example basic is a built-in/general-purpose scope for common OIDC claims. If we put objectidentifier there, we can make a custom business-critical claim look like part of the standard/basic claim set.

By adding a custom scope it makes it obvious why the claim exists and which clients depend on it. We can also make a more generic "fint" scope, open for ideas here.